### PR TITLE
ensure LF line endings for shell scripts and make entrypoint executable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ensure shell scripts use LF endings in working tree to avoid /bin/bash\r issues in Linux containers
+*.sh text eol=lf

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -49,7 +49,9 @@ ENV UVICORN_HOST=0.0.0.0
 ENV UVICORN_PORT=8000
 
 COPY ./cuda-docker-entrypoint.sh /workspace/docker-entrypoint.sh
-RUN chmod +x /workspace/docker-entrypoint.sh
+# Ensure script has LF line endings and is executable (Windows checkouts may have CRLF)
+RUN sed -i 's/\r$//' /workspace/docker-entrypoint.sh \
+    && chmod +x /workspace/docker-entrypoint.sh
 
 ENTRYPOINT [ "/workspace/docker-entrypoint.sh" ]
 


### PR DESCRIPTION
# Fix: EntryPoint CRLF Causes `no such file or directory` on CUDA Image

## Summary
Fix runtime failure of the CUDA service where the container exited with:

```
exec /workspace/docker-entrypoint.sh: no such file or directory
```

The issue was caused by Windows CRLF line endings in the entrypoint shell script, making the shebang line unreadable in the Linux container. This PR normalizes line endings during the image build and prevents future recurrence.

## Root Cause
- `cuda-docker-entrypoint.sh` was checked out with CRLF on Windows.
- Inside the Linux CUDA image, `/bin/bash` couldn’t exec the script because of the hidden `\r` characters.
- Docker showed a misleading “no such file or directory” even though the path existed and permissions were set.

## Changes
- Updated `Dockerfile.cuda`:
  - Added a `sed -i 's/\r$//' /workspace/docker-entrypoint.sh` step before `chmod` to strip CRLF.
- Added `.gitattributes`:
  - Forces LF endings for all `*.sh` files to prevent future CRLF issues.

## Files Modified
- `Dockerfile.cuda`
- `.gitattributes` (new)

## How to Reproduce (Before Fix)
```bash
docker compose build whisperx-api-server-cuda
docker compose up whisperx-api-server-cuda
# Container exits immediately with: exec /workspace/docker-entrypoint.sh: no such file or directory
```

## Verification (After Fix)
```bash
docker compose build --no-cache whisperx-api-server-cuda
docker compose up whisperx-api-server-cuda
# Service stays up; entrypoint selects GPU and uvicorn serves on 0.0.0.0:8000
```

Optional sanity check:
```bash
docker run --rm whisperx-api-server-cuda bash -c "file /workspace/docker-entrypoint.sh"
# Output shows ASCII text (no CRLF)
```

## Impact
- Resolves startup failure on Windows-based contributors.
- Improves reliability of multi-platform development (Windows host -> Linux container).
- No functional changes to application logic.

## Testing
- Manual build/run on Windows host confirmed container now starts normally.
- Entrypoint still passes through `uvicorn` command (`exec "$@"` preserved).

## Risks
Low. Change is isolated to build steps and git attributes. No runtime code paths altered.

## Future Improvements (Optional)
- Apply same CRLF safeguard to `Dockerfile.cpu`.
- Add a lightweight container test (e.g., GitHub Actions) to assert entrypoint execution.
- Consider multi-stage caching optimizations for Python dependencies.

## Checklist
- [x] Build succeeds
- [x] Container starts
- [x] Entrypoint selects GPU and defers to uvicorn
- [x] No unintended changes to API code
- [x] Added preventive `.gitattributes`
