### PR TITLE
Optimizations

### DIFF
--- a/src/whisperx_api_server/backends/contracts.py
+++ b/src/whisperx_api_server/backends/contracts.py
@@ -30,7 +30,7 @@ class TranscriptionBackend(Protocol):
     async def load_model(self, model_name: str) -> None:
         ...
 
-    def unload_model(self, model_name: str) -> bool:
+    async def unload_model(self, model_name: str) -> bool:
         ...
 
     async def transcribe(
@@ -58,7 +58,7 @@ class AlignmentBackend(Protocol):
     async def load_model(self, model_name: str) -> None:
         ...
 
-    def unload_model(self, model_name: str) -> bool:
+    async def unload_model(self, model_name: str) -> bool:
         ...
 
     async def align(
@@ -81,7 +81,7 @@ class DiarizationBackend(Protocol):
     async def load_model(self, model_name: str) -> None:
         ...
 
-    def unload_model(self, model_name: str) -> bool:
+    async def unload_model(self, model_name: str) -> bool:
         ...
 
     async def diarize(

--- a/src/whisperx_api_server/backends/whisperx_backend.py
+++ b/src/whisperx_api_server/backends/whisperx_backend.py
@@ -12,15 +12,27 @@ from whisperx import diarize as whisperx_diarize
 
 from whisperx_api_server.config import Language
 from whisperx_api_server.dependencies import get_config
+from whisperx_api_server.executors import get_model_executor, get_io_executor
 from .whisperx_runtime import (
     align_model_instances,
+    alignment_cache_mod_lock,
+    alignment_locks,
+    acquire_align_model,
+    acquire_diarize_pipeline,
+    acquire_transcribe_pipeline,
+    align_cache_key_for,
     determine_inference_device,
+    diarize_locks,
     diarize_pipeline_instances,
     load_align_model,
     load_diarize_pipeline,
     load_transcribe_pipeline,
+    release_align_model,
+    release_diarize_pipeline,
+    release_transcribe_pipeline,
     transcribe_pipeline_instances,
-    unload_model_object,
+    transcribe_pipeline_locks,
+    unload_model_object_async,
 )
 
 from .registry import (
@@ -83,13 +95,31 @@ class WhisperXTranscriptionBackend:
     async def load_model(self, model_name: str) -> None:
         await load_transcribe_pipeline(model_name=model_name)
 
-    def unload_model(self, model_name: str) -> bool:
+    async def unload_model(self, model_name: str) -> bool:
+        # Pop first so no new request can grab this instance from the cache.
+        # New requests calling load_transcribe_pipeline() will then get a fresh
+        # lock from the defaultdict, isolated from our teardown.
+        #
+        # Old in-flight requests already hold a reference to the popped lock
+        # (via getattr(model, "_transcribe_lock", ...)), so we hold the lock
+        # for the entire teardown — both pre-existing critical sections and
+        # post-pop callers serialize behind us, and once we release the lock
+        # they would still see a torn-down model. Acceptable: the request
+        # would either succeed on CPU or surface a backend error mapped to 5xx.
         to_remove = [k for k in transcribe_pipeline_instances if k[0] == model_name]
+        if not to_remove:
+            return False
         for cache_key in to_remove:
             pipeline = transcribe_pipeline_instances.pop(cache_key, None)
-            if pipeline is not None:
-                unload_model_object(pipeline)
-        return bool(to_remove)
+            lock = transcribe_pipeline_locks.pop(cache_key, None)
+            if pipeline is None:
+                continue
+            if lock is not None:
+                async with lock:
+                    await unload_model_object_async(pipeline)
+            else:
+                await unload_model_object_async(pipeline)
+        return True
 
     async def transcribe(
         self,
@@ -115,6 +145,7 @@ class WhisperXTranscriptionBackend:
         )
 
         lock = getattr(model, "_transcribe_lock", None)
+        cache_key = getattr(model, "_cache_key", None)
 
         def _run_transcription() -> dict[str, Any]:
             with torch.inference_mode():
@@ -127,13 +158,20 @@ class WhisperXTranscriptionBackend:
                     task=task,
                 )
 
-        if lock is not None:
-            async with lock:
+        # Refcount so concurrent /models/unload can see this pipeline is in use.
+        if cache_key is not None:
+            acquire_transcribe_pipeline(cache_key)
+        try:
+            if lock is not None:
+                async with lock:
+                    _apply_request_options(model, asr_options)
+                    result = await loop.run_in_executor(get_model_executor(), _run_transcription)
+            else:
                 _apply_request_options(model, asr_options)
-                result = await loop.run_in_executor(None, _run_transcription)
-        else:
-            _apply_request_options(model, asr_options)
-            result = await loop.run_in_executor(None, _run_transcription)
+                result = await loop.run_in_executor(get_model_executor(), _run_transcription)
+        finally:
+            if cache_key is not None:
+                release_transcribe_pipeline(cache_key)
 
         logger.info(
             f"Request ID: {request_id} - Transcription completed using backend=whisperx")
@@ -160,11 +198,21 @@ class WhisperXAlignmentBackend:
     async def load_model(self, model_name: str) -> None:
         await load_align_model(model_name)
 
-    def unload_model(self, model_name: str) -> bool:
-        align_model_data = align_model_instances.pop(model_name, None)
+    async def unload_model(self, model_name: str) -> bool:
+        # Pop atomically against the cache-eviction lock so concurrent
+        # whitelist cleanup can't race the same key. Hold the per-key lock
+        # for the entire teardown — both in-flight `align()` callers and the
+        # whitelist cleanup serialize behind it.
+        async with alignment_cache_mod_lock:
+            align_model_data = align_model_instances.pop(model_name, None)
+            lock = alignment_locks.pop(model_name, None)
         if align_model_data is None:
             return False
-        unload_model_object(align_model_data.get("model"))
+        if lock is not None:
+            async with lock:
+                await unload_model_object_async(align_model_data.get("model"))
+        else:
+            await unload_model_object_async(align_model_data.get("model"))
         return True
 
     async def align(
@@ -182,29 +230,37 @@ class WhisperXAlignmentBackend:
 
         loop = asyncio.get_running_loop()
         device = determine_inference_device()
+        cache_key = align_cache_key_for(language_code)
 
-        alignment_model_start = time.perf_counter()
-        logger.info(
-            f"Request ID: {request_id} - Loading alignment model backend=whisperx language={language_code}"
-        )
-        model_a, metadata = await load_align_model(language_code=language_code)
-        logger.info(
-            f"Request ID: {request_id} - Alignment model loaded in {time.perf_counter() - alignment_model_start:.2f} seconds"
-        )
+        # Increment refcount before load so eviction skips this key while we hold it.
+        acquire_align_model(language_code)
+        try:
+            alignment_model_start = time.perf_counter()
+            logger.info(
+                f"Request ID: {request_id} - Loading alignment model backend=whisperx language={language_code}"
+            )
+            model_a, metadata = await load_align_model(language_code=language_code)
+            logger.info(
+                f"Request ID: {request_id} - Alignment model loaded in {time.perf_counter() - alignment_model_start:.2f} seconds"
+            )
 
-        def _run_alignment() -> Any:
-            with torch.inference_mode():
-                return whisperx_alignment.align(
-                    transcript=result["segments"],
-                    model=model_a,
-                    align_model_metadata=metadata,
-                    audio=audio,
-                    device=device,
-                    return_char_alignments=False,
-                )
+            def _run_alignment() -> Any:
+                with torch.inference_mode():
+                    return whisperx_alignment.align(
+                        transcript=result["segments"],
+                        model=model_a,
+                        align_model_metadata=metadata,
+                        audio=audio,
+                        device=device,
+                        return_char_alignments=False,
+                    )
 
-        alignment_start = time.perf_counter()
-        result["segments"] = await loop.run_in_executor(None, _run_alignment)
+            alignment_start = time.perf_counter()
+            async with alignment_locks[cache_key]:
+                result["segments"] = await loop.run_in_executor(get_model_executor(), _run_alignment)
+        finally:
+            release_align_model(language_code)
+
         logger.info(
             f"Request ID: {request_id} - Alignment completed using backend=whisperx in {time.perf_counter() - alignment_start:.2f} seconds"
         )
@@ -223,11 +279,19 @@ class WhisperXDiarizationBackend:
     async def load_model(self, model_name: str) -> None:
         await load_diarize_pipeline(model_name=model_name)
 
-    def unload_model(self, model_name: str) -> bool:
+    async def unload_model(self, model_name: str) -> bool:
+        # Pop first so new requests get a fresh cache miss path. Hold the
+        # popped lock during teardown so any in-flight diarize that already
+        # has a reference to the old pipeline finishes before we tear it down.
         model = diarize_pipeline_instances.pop(model_name, None)
+        lock = diarize_locks.pop(model_name, None)
         if model is None:
             return False
-        unload_model_object(model)
+        if lock is not None:
+            async with lock:
+                await unload_model_object_async(model)
+        else:
+            await unload_model_object_async(model)
         return True
 
     async def diarize(
@@ -259,12 +323,22 @@ class WhisperXDiarizationBackend:
                     return diarize_model(audio=audio, return_embeddings=True)
                 return diarize_model(audio=audio), None
 
+        # Refcount so concurrent /diarize_models/unload sees this is in use.
+        acquire_diarize_pipeline(config.diarization.model)
         diarize_start = time.perf_counter()
-        diarize_segments, embeddings = await loop.run_in_executor(None, _run_diarization)
-        result["segments"] = whisperx_diarize.assign_word_speakers(
-            diarize_segments,
-            result["segments"],
-            embeddings,
+        try:
+            async with diarize_locks[config.diarization.model]:
+                diarize_segments, embeddings = await loop.run_in_executor(get_model_executor(), _run_diarization)
+        finally:
+            release_diarize_pipeline(config.diarization.model)
+        # Lock released before CPU-only word assignment so the diarize slot is free sooner.
+        result["segments"] = await loop.run_in_executor(
+            get_io_executor(),
+            lambda: whisperx_diarize.assign_word_speakers(
+                diarize_segments,
+                result["segments"],
+                embeddings,
+            ),
         )
         logger.info(
             f"Request ID: {request_id} - Diarization completed using backend=whisperx in {time.perf_counter() - diarize_start:.2f} seconds"

--- a/src/whisperx_api_server/backends/whisperx_runtime.py
+++ b/src/whisperx_api_server/backends/whisperx_runtime.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import gc
 import logging
+import os
 from asyncio import Lock
 from collections import defaultdict
 from typing import Any, Dict, Optional, Tuple
@@ -13,8 +14,22 @@ from whisperx import transcribe as whisperx_transcribe
 from whisperx.asr import FasterWhisperPipeline
 
 from whisperx_api_server.dependencies import get_config
+from whisperx_api_server.executors import get_io_executor
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_ct2_threads(configured: int, device: str) -> int:
+    # User-specified value wins.
+    if configured and configured > 0:
+        return configured
+    # CT2 treats 0 as "OMP_NUM_THREADS or hardcoded 4", so we pick explicitly.
+    # CPU device: saturate the box. CUDA device: CT2 only needs a few CPU threads
+    # for tokenization / mel-spec / beam bookkeeping; oversubscribing starves
+    # PyTorch align/diarize threads.
+    if device == "cpu":
+        return os.cpu_count() or 4
+    return 4
 
 
 def _hashable_options(opts: Any) -> Any:
@@ -31,15 +46,62 @@ def _hashable_options(opts: Any) -> Any:
 transcribe_pipeline_instances: Dict[Tuple[Any, ...],
                                     FasterWhisperPipeline] = {}
 transcribe_pipeline_locks = defaultdict(Lock)
+transcribe_in_use: defaultdict[Tuple[Any, ...], int] = defaultdict(int)
 align_model_instances: dict[str, dict[str, Any]] = {}
 alignment_locks = defaultdict(Lock)
 alignment_cache_mod_lock = Lock()
+align_in_use: defaultdict[str, int] = defaultdict(int)
 diarize_pipeline_instances: dict[str,
                                  whisperx_diarize.DiarizationPipeline] = {}
 diarize_locks = defaultdict(Lock)
+diarize_in_use: defaultdict[str, int] = defaultdict(int)
+
+
+def align_cache_key_for(language_code: str) -> str:
+    """Returns the cache key used in align_model_instances for the given language_code."""
+    config = get_config()
+    if "multilingual" in config.alignment.models:
+        return "multilingual"
+    return language_code
+
+
+def acquire_align_model(language_code: str) -> None:
+    align_in_use[align_cache_key_for(language_code)] += 1
+
+
+def release_align_model(language_code: str) -> None:
+    key = align_cache_key_for(language_code)
+    if align_in_use[key] > 0:
+        align_in_use[key] -= 1
+
+
+def acquire_transcribe_pipeline(cache_key: Tuple[Any, ...]) -> None:
+    transcribe_in_use[cache_key] += 1
+
+
+def release_transcribe_pipeline(cache_key: Tuple[Any, ...]) -> None:
+    if transcribe_in_use[cache_key] > 0:
+        transcribe_in_use[cache_key] -= 1
+    if transcribe_in_use[cache_key] == 0:
+        transcribe_in_use.pop(cache_key, None)
+
+
+def acquire_diarize_pipeline(model_name: str) -> None:
+    diarize_in_use[model_name] += 1
+
+
+def release_diarize_pipeline(model_name: str) -> None:
+    if diarize_in_use[model_name] > 0:
+        diarize_in_use[model_name] -= 1
+    if diarize_in_use[model_name] == 0:
+        diarize_in_use.pop(model_name, None)
 
 
 def unload_model_object(model_obj: Any) -> None:
+    """Move a model off GPU and free CUDA cache. Blocking — callers from the
+    event loop should run this via `loop.run_in_executor(get_io_executor(), ...)`
+    because `model.to("cpu")` and `torch.cuda.empty_cache()` synchronize CUDA.
+    """
     if model_obj is None:
         return
     with contextlib.suppress(Exception):
@@ -49,7 +111,16 @@ def unload_model_object(model_obj: Any) -> None:
             model_obj.model.to("cpu")
     del model_obj
     gc.collect()
-    torch.cuda.empty_cache()
+    with contextlib.suppress(Exception):
+        torch.cuda.empty_cache()
+
+
+async def unload_model_object_async(model_obj: Any) -> None:
+    """Async wrapper that offloads the blocking GPU teardown to the IO executor."""
+    if model_obj is None:
+        return
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(get_io_executor(), unload_model_object, model_obj)
 
 
 def check_device() -> str:
@@ -128,26 +199,30 @@ async def load_transcribe_pipeline(model_name: str) -> FasterWhisperPipeline:
             vad_options=config.whisper.vad_options,
             download_root=config.whisper.download_root,
             local_files_only=config.whisper.local_files_only,
-            threads=config.whisper.cpu_threads or 4,
+            threads=_resolve_ct2_threads(config.whisper.cpu_threads, inference_device),
             use_auth_token=config.hf_token,
         )
 
+    loop = asyncio.get_running_loop()
     if not config.whisper.cache:
         logger.info(
             f"Initializing transcribe pipeline without cache: {cache_key}")
-        pipeline = await asyncio.to_thread(_create_pipeline)
-        pipeline._transcribe_lock = transcribe_pipeline_locks[cache_key]
+        pipeline = await loop.run_in_executor(get_io_executor(), _create_pipeline)
+        pipeline._transcribe_lock = asyncio.Lock()
+        pipeline._cache_key = None  # uncached: unload-time refcount doesn't apply
         return pipeline
 
     pipeline = await _get_or_init_model(
         key=cache_key,
         cache_dict=transcribe_pipeline_instances,
         lock_dict=transcribe_pipeline_locks,
-        init_func=lambda: asyncio.to_thread(_create_pipeline),
+        init_func=lambda: loop.run_in_executor(
+            get_io_executor(), _create_pipeline),
         log_reuse="Reusing cached transcribe pipeline: {key}",
         log_init="Initializing transcribe pipeline: {key}",
     )
     pipeline._transcribe_lock = transcribe_pipeline_locks[cache_key]
+    pipeline._cache_key = cache_key
     return pipeline
 
 
@@ -158,13 +233,19 @@ async def _cleanup_alignment_cache_whitelist(keep_key: Optional[str] = None) -> 
         return
     async with alignment_cache_mod_lock:
         keys_to_remove = [
-            k for k in align_model_instances if k not in whitelist and k != keep_key]
+            k for k in align_model_instances
+            if k not in whitelist and k != keep_key and align_in_use[k] == 0
+        ]
         for key in keys_to_remove:
             logger.info(
                 f"Unloading alignment model for {key} (not in whitelist).")
             align_model_data = align_model_instances.pop(key, None)
+            # Drop the per-key lock so the defaultdict doesn't grow unbounded
+            # over the process lifetime as languages come and go.
+            alignment_locks.pop(key, None)
+            align_in_use.pop(key, None)
             if align_model_data:
-                unload_model_object(align_model_data.get("model"))
+                await unload_model_object_async(align_model_data.get("model"))
                 del align_model_data
 
 
@@ -204,7 +285,7 @@ async def load_align_model(
     async def _init_alignment() -> Tuple[Any, Dict[str, Any]]:
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(
-            None,
+            get_io_executor(),
             lambda: whisperx_alignment.load_align_model(
                 language_code=language_code,
                 device=inference_device,
@@ -245,16 +326,18 @@ async def load_diarize_pipeline(model_name: str) -> whisperx_diarize.Diarization
             device=inference_device,
         )
 
+    loop = asyncio.get_running_loop()
     if not config.diarization.cache:
         logger.info(
             f"Initializing diarization model without cache: {model_name}")
-        return await asyncio.to_thread(_init_diarization)
+        return await loop.run_in_executor(get_io_executor(), _init_diarization)
 
     diarize_model = await _get_or_init_model(
         key=model_name,
         cache_dict=diarize_pipeline_instances,
         lock_dict=diarize_locks,
-        init_func=lambda: asyncio.to_thread(_init_diarization),
+        init_func=lambda: loop.run_in_executor(
+            get_io_executor(), _init_diarization),
         log_reuse="Reusing cached diarization model for: {key}",
         log_init="Initializing diarization model: {key}",
     )

--- a/src/whisperx_api_server/config.py
+++ b/src/whisperx_api_server/config.py
@@ -160,6 +160,10 @@ class WhisperConfig(BaseModel):
     inference_device: Device = Field(default=Device.AUTO)
     device_index: int | list[int] = Field(default=0)
     compute_type: Quantization = Field(default=Quantization.DEFAULT)
+    # CTranslate2 intra-op threads. 0 = auto: os.cpu_count() on CPU device, 4 on CUDA.
+    # NOTE: CTranslate2 itself treats 0 as "OMP_NUM_THREADS or hardcoded 4", so we resolve
+    # explicitly at load time. On CUDA, CT2 only uses these threads for tokenization /
+    # mel-spec / beam bookkeeping — saturating cores there starves align/diarize.
     cpu_threads: int = Field(default=0)
     num_workers: int = Field(default=1)
     vad_method: VadMethod = Field(default=VadMethod.PYANNOTE)
@@ -192,6 +196,9 @@ class AlignConfig(BaseModel):
     preload_model: bool = Field(default=False)
     preload_model_name: str = Field(default=None)
     local_files_only: bool = Field(default=False)
+    # Download NLTK punkt_tab tokenizer at startup so the first alignment request
+    # does not block an executor thread on a network call.
+    nltk_preload: bool = Field(default=True)
 
 
 class DiarizeConfig(BaseModel):
@@ -216,11 +223,17 @@ class KafkaConfig(BaseModel):
     request_topic: str = Field(default="transcription-requests")
     reply_topic: str = Field(default="transcription-replies")
     consumer_group_worker: str = Field(default="whisperx-worker")
+    # Stable group id for the API-side reply consumer. Replicas of the API
+    # share this group so each reply is delivered exactly once. When running
+    # multiple replicas, each replica MUST set a unique `reply_group_instance_id`
+    # (Kafka static membership) to avoid rebalance churn on restart.
+    reply_group_id: str = Field(default="whisperx-api-reply")
+    reply_group_instance_id: str | None = Field(default=None)
     reply_timeout_seconds: float = Field(default=3600.0)
     max_poll_interval_ms: int = Field(default=600_000)
     # Maximum number of jobs waiting for a reply (0 = unlimited).
     # Requests beyond this limit are rejected with HTTP 503.
-    max_pending_jobs: int = Field(default=0)
+    max_pending_jobs: int = Field(default=100)
     # Must match broker KAFKA_MESSAGE_MAX_BYTES (default 50 MiB).
     max_message_bytes: int = Field(default=52428800)
 
@@ -234,6 +247,8 @@ class S3Config(BaseModel):
     delete_after_download: bool = Field(default=True)
     # Lifecycle expiry for objects in the bucket (days). 0 = disabled.
     object_expiry_days: int = Field(default=1)
+    # When true, apply a bucket lifecycle rule on startup. Requires object_expiry_days > 0.
+    manage_lifecycle: bool = Field(default=False)
 
 
 class MetricsConfig(BaseModel):
@@ -288,10 +303,25 @@ class Config(BaseSettings):
 
     cache_cleanup: bool = True
 
+    # Seconds between periodic torch.cuda.empty_cache() flushes (0 = disabled).
+    cache_cleanup_interval: int = Field(default=0, ge=0)
+
     audio_cleanup: bool = True
 
-    # Maximum number of concurrent GPU transcriptions (0 = unlimited, only applies when CUDA is available)
-    max_concurrent_transcriptions: int = 1
+    # Max concurrent ML inferences (transcribe/align/diarize). 0 = unlimited. Applied on both
+    # CPU and CUDA. The decode admission limit is automatically set to n+1 so one ffmpeg
+    # decode can overlap with the in-flight inference.
+    max_concurrent_transcriptions: int = Field(default=1, ge=0)
+
+    # Hard limit on upload size in bytes. 0 = unlimited (default). Enforced while
+    # streaming the upload to the temp file, so we don't materialize huge bodies
+    # on disk before rejecting.
+    max_upload_size_bytes: int = Field(default=0, ge=0)
+
+    # On SIGTERM, refuse new requests with HTTP 503 and wait up to this many
+    # seconds for in-flight work to drain before tearing down. Best-effort on
+    # Windows (signal handlers raise NotImplementedError under ProactorEventLoop).
+    shutdown_grace_seconds: int = Field(default=30, ge=0)
 
     hf_token: str = Field(alias="HF_TOKEN", default="", repr=False)
 

--- a/src/whisperx_api_server/config.py
+++ b/src/whisperx_api_server/config.py
@@ -293,9 +293,6 @@ class Config(BaseSettings):
     # Maximum number of concurrent GPU transcriptions (0 = unlimited, only applies when CUDA is available)
     max_concurrent_transcriptions: int = 1
 
-    # Thread-pool workers for async I/O (audio load/save)
-    io_executor_workers: int = 4
-
     hf_token: str = Field(alias="HF_TOKEN", default="", repr=False)
 
     mode: DistributedMode = Field(default=DistributedMode.DIRECT)

--- a/src/whisperx_api_server/executors.py
+++ b/src/whisperx_api_server/executors.py
@@ -1,0 +1,39 @@
+import logging
+from concurrent.futures import ThreadPoolExecutor
+
+logger = logging.getLogger(__name__)
+
+_model_executor: ThreadPoolExecutor | None = None
+_io_executor: ThreadPoolExecutor | None = None
+
+
+def get_model_executor() -> ThreadPoolExecutor:
+    global _model_executor
+    if _model_executor is None:
+        from whisperx_api_server.dependencies import get_config
+        config = get_config()
+        n = max(1, config.max_concurrent_transcriptions)
+        _model_executor = ThreadPoolExecutor(max_workers=n, thread_name_prefix="wx-model")
+        logger.info("model thread pool: %d workers", n)
+    return _model_executor
+
+
+def get_io_executor() -> ThreadPoolExecutor:
+    global _io_executor
+    if _io_executor is None:
+        from whisperx_api_server.dependencies import get_config
+        config = get_config()
+        n = min(32, 4 * max(1, config.max_concurrent_transcriptions))
+        _io_executor = ThreadPoolExecutor(max_workers=n, thread_name_prefix="wx-io")
+        logger.info("IO thread pool: %d workers", n)
+    return _io_executor
+
+
+def shutdown_executors() -> None:
+    global _model_executor, _io_executor
+    for name, ex in [("model", _model_executor), ("io", _io_executor)]:
+        if ex is not None:
+            ex.shutdown(wait=False)
+            logger.info("%s executor shut down", name)
+    _model_executor = None
+    _io_executor = None

--- a/src/whisperx_api_server/kafka_client.py
+++ b/src/whisperx_api_server/kafka_client.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import logging
-import socket
 import time
 from typing import Any
 
@@ -13,6 +12,28 @@ logger = logging.getLogger(__name__)
 _producer = None
 _config: KafkaConfig | None = None
 _pending_jobs: dict[str, tuple[asyncio.Future, float]] = {}
+
+
+def _rehydrate_worker_error(error_type: str | None, message: str) -> BaseException:
+    """Map worker-side exception class name → API-side exception class so the
+    typed-error → HTTP-code router mapping still works when the failure
+    originates in a worker process. Lazy import avoids a transcriber↔kafka_client
+    cycle.
+    """
+    if error_type:
+        from whisperx_api_server.transcriber import (
+            InvalidAudioError, UploadTooLargeError,
+        )
+        mapping: dict[str, type[BaseException]] = {
+            "InvalidAudioError": InvalidAudioError,
+            "UploadTooLargeError": UploadTooLargeError,
+            "TimeoutError": TimeoutError,
+            "ValueError": ValueError,
+        }
+        cls = mapping.get(error_type, RuntimeError)
+    else:
+        cls = RuntimeError
+    return cls(message)
 
 
 async def start(cfg: KafkaConfig) -> None:
@@ -67,19 +88,25 @@ async def submit_job(
 async def reply_consumer_loop(cfg: KafkaConfig) -> None:
     from aiokafka import AIOKafkaConsumer
 
-    group_id = f"whisperx-api-reply-{socket.gethostname()}"
-    consumer = AIOKafkaConsumer(
-        cfg.reply_topic,
+    consumer_kwargs: dict[str, Any] = dict(
         bootstrap_servers=cfg.bootstrap_servers,
-        group_id=group_id,
-        auto_offset_reset="earliest",
-        enable_auto_commit=True,
+        group_id=cfg.reply_group_id,
+        auto_offset_reset="latest",
+        enable_auto_commit=False,
         fetch_max_bytes=cfg.max_message_bytes,
         max_partition_fetch_bytes=cfg.max_message_bytes,
     )
+    if cfg.reply_group_instance_id:
+        consumer_kwargs["group_instance_id"] = cfg.reply_group_instance_id
+
+    consumer = AIOKafkaConsumer(cfg.reply_topic, **consumer_kwargs)
     await consumer.start()
     logger.info(
-        f"Kafka reply consumer started (group: {group_id}, topic: {cfg.reply_topic})")
+        "Kafka reply consumer started (group: %s, instance: %s, topic: %s)",
+        cfg.reply_group_id,
+        cfg.reply_group_instance_id or "<dynamic>",
+        cfg.reply_topic,
+    )
     try:
         async for msg in consumer:
             try:
@@ -87,30 +114,35 @@ async def reply_consumer_loop(cfg: KafkaConfig) -> None:
             except Exception:
                 logger.warning(
                     "Reply consumer: failed to parse message, skipping")
+                await consumer.commit()
                 continue
 
             job_id = event.get("job_id")
-            if not job_id:
-                continue
+            if job_id:
+                entry = _pending_jobs.pop(job_id, None)
+                if entry is not None:
+                    future, submit_time = entry
+                    if not future.done():
+                        duration = time.monotonic() - submit_time
+                        if event.get("status") == "ok":
+                            future.set_result(event["result"])
+                            _kafka.job_duration.labels(status="ok").observe(duration)
+                            logger.debug(f"Job {job_id}: resolved from reply")
+                        else:
+                            future.set_exception(_rehydrate_worker_error(
+                                event.get("error_type"),
+                                event.get("error", "worker error"),
+                            ))
+                            _kafka.job_duration.labels(status="error").observe(duration)
+                            logger.warning(
+                                f"Job {job_id}: failed with error: {event.get('error')}")
 
-            entry = _pending_jobs.pop(job_id, None)
-            if entry is None:
-                continue
-            future, submit_time = entry
-            if future.done():
-                continue
-
-            duration = time.monotonic() - submit_time
-            if event.get("status") == "ok":
-                future.set_result(event["result"])
-                _kafka.job_duration.labels(status="ok").observe(duration)
-                logger.debug(f"Job {job_id}: resolved from reply")
-            else:
-                future.set_exception(RuntimeError(
-                    event.get("error", "worker error")))
-                _kafka.job_duration.labels(status="error").observe(duration)
-                logger.warning(
-                    f"Job {job_id}: failed with error: {event.get('error')}")
+            try:
+                await consumer.commit()
+            except Exception:
+                logger.exception(
+                    "Reply consumer: failed to commit offset for job %s", job_id
+                )
     finally:
         await consumer.stop()
         logger.info("Kafka reply consumer stopped")

--- a/src/whisperx_api_server/main.py
+++ b/src/whisperx_api_server/main.py
@@ -1,6 +1,8 @@
 import asyncio
 import contextlib
 import logging
+import re
+import signal
 import uuid
 from fastapi import (
     FastAPI,
@@ -9,6 +11,8 @@ from fastapi import (
 from contextlib import asynccontextmanager
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Scope, Receive, Send
 
 from whisperx_api_server.config import DistributedMode
 from whisperx_api_server.dependencies import ApiKeyDependency, get_config
@@ -34,19 +38,136 @@ from whisperx_api_server.routers.transcriptions import (
 )
 
 
+_REQUEST_ID_SAFE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
+
+
 class RequestIDMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
-        request_id = request.headers.get("X-Request-ID", str(uuid.uuid4()))
+        # Validate client-supplied X-Request-ID so log lines / response headers
+        # cannot be poisoned with CR/LF or other control chars.
+        client_id = request.headers.get("X-Request-ID")
+        if client_id and _REQUEST_ID_SAFE.match(client_id):
+            request_id = client_id
+        else:
+            request_id = str(uuid.uuid4())
         request.state.request_id = request_id
         response = await call_next(request)
         response.headers["X-Request-ID"] = request_id
         return response
 
 
+class GracefulShutdownMiddleware:
+    """ASGI middleware that refuses new requests with HTTP 503 while the app
+    is draining, and tracks an in-flight counter on `app.state` so the
+    lifespan can await an empty queue before tearing down.
+
+    Health/metrics endpoints stay reachable during drain so liveness probes
+    do not flip the pod to CrashLoopBackoff before drain finishes.
+    """
+
+    _DRAIN_PASSTHROUGH_PATHS: frozenset[str] = frozenset(
+        {"/metrics", "/healthcheck"}
+    )
+
+    def __init__(self, app: ASGIApp, app_state) -> None:
+        self.app = app
+        self.app_state = app_state
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        path: str = scope.get("path", "")
+        if path in self._DRAIN_PASSTHROUGH_PATHS:
+            await self.app(scope, receive, send)
+            return
+
+        if getattr(self.app_state, "shutting_down", False):
+            response = JSONResponse(
+                {"detail": "Server is shutting down."},
+                status_code=503,
+                headers={"Connection": "close", "Retry-After": "5"},
+            )
+            await response(scope, receive, send)
+            return
+
+        self.app_state.inflight += 1
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            self.app_state.inflight -= 1
+            if self.app_state.inflight <= 0:
+                drain_event: asyncio.Event | None = getattr(
+                    self.app_state, "drain_event", None
+                )
+                if drain_event is not None:
+                    drain_event.set()
+
+
+async def _drain_inflight(app_state, grace_seconds: int, logger: logging.Logger) -> None:
+    """Wait up to `grace_seconds` for the in-flight counter to reach zero."""
+    if app_state.inflight <= 0:
+        return
+
+    drain_event = asyncio.Event()
+    app_state.drain_event = drain_event
+    if app_state.inflight <= 0:
+        return
+
+    logger.info(
+        "Draining %d in-flight request(s) (grace=%ds)",
+        app_state.inflight,
+        grace_seconds,
+    )
+    try:
+        await asyncio.wait_for(drain_event.wait(), timeout=grace_seconds)
+        logger.info("All in-flight requests drained")
+    except asyncio.TimeoutError:
+        logger.warning(
+            "Drain grace expired with %d request(s) still in flight",
+            app_state.inflight,
+        )
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     logger = logging.getLogger(__name__)
     config = get_config()
+
+    app.state.shutting_down = False
+    app.state.inflight = 0
+    app.state.drain_event = None
+
+    sigterm_registered = False
+    chained_handler = None
+    try:
+        loop = asyncio.get_running_loop()
+        # Capture and chain to uvicorn's existing SIGTERM handler so its
+        # graceful shutdown still fires after we flip the drain flag.
+        prev = getattr(loop, "_signal_handlers", {}).get(signal.SIGTERM)
+        if prev is not None and not getattr(prev, "_cancelled", False):
+            chained_handler = (prev._callback, prev._args)
+
+        def _request_shutdown() -> None:
+            if not app.state.shutting_down:
+                app.state.shutting_down = True
+                logger.info(
+                    "SIGTERM received — refusing new requests, draining in-flight work"
+                )
+            if chained_handler is not None:
+                cb, args = chained_handler
+                try:
+                    cb(*args)
+                except Exception:
+                    logger.exception("Previous SIGTERM handler raised")
+
+        loop.add_signal_handler(signal.SIGTERM, _request_shutdown)
+        sigterm_registered = True
+    except NotImplementedError:
+        logger.info(
+            "SIGTERM handler unavailable on this platform; relying on lifespan teardown"
+        )
 
     gpu_task: "asyncio.Task | None" = None
     if config.metrics.enabled:
@@ -67,6 +188,18 @@ async def lifespan(app: FastAPI):
             gpu_task.add_done_callback(_on_gpu_task_done)
             logger.info("GPU metrics poller started (interval=%ss)",
                         config.metrics.gpu_poll_interval)
+
+    from whisperx_api_server.transcriber import init_concurrency
+    from whisperx_api_server.executors import shutdown_executors
+    init_concurrency()
+
+    if config.alignment.nltk_preload:
+        try:
+            import nltk
+            await asyncio.to_thread(nltk.download, "punkt_tab", quiet=True)
+            logger.info("NLTK punkt_tab preloaded")
+        except Exception:
+            logger.warning("NLTK punkt_tab preload failed; will be downloaded on first alignment request")
 
     try:
         if config.mode == DistributedMode.KAFKA:
@@ -124,6 +257,17 @@ async def lifespan(app: FastAPI):
                     "Failed to preload diarization backend; will try to load on demand")
             yield
     finally:
+        # Flip the drain flag before teardown so any final in-flight requests
+        # see HTTP 503. If SIGTERM already fired, this is a no-op.
+        if not app.state.shutting_down:
+            app.state.shutting_down = True
+        await _drain_inflight(app.state, config.shutdown_grace_seconds, logger)
+
+        if sigterm_registered:
+            with contextlib.suppress(NotImplementedError, RuntimeError):
+                asyncio.get_running_loop().remove_signal_handler(signal.SIGTERM)
+
+        shutdown_executors()
         # -------- GPU Task shutdown --------
         if gpu_task is not None:
             gpu_task.cancel()
@@ -173,7 +317,18 @@ def create_app() -> FastAPI:
         logger.info(
             "Observability: /metrics endpoint registered (unauthenticated)")
 
-    app.include_router(models_router, dependencies=dependencies)
+    # Model-management endpoints operate on the API process's local cache.
+    # In Kafka mode the API process never loads models (the worker does), so
+    # /models/*, /align_models/*, /diarize_models/* would either lie about
+    # cache state or wastefully load models into the API container. Skip them
+    # entirely so callers see a clean 404 instead of misleading 200/500.
+    if config.mode != DistributedMode.KAFKA:
+        app.include_router(models_router, dependencies=dependencies)
+    else:
+        logger.info(
+            "Kafka mode: /models/*, /align_models/*, /diarize_models/* endpoints "
+            "are disabled (model lifecycle lives in worker processes)"
+        )
     app.include_router(transcribe_router, dependencies=dependencies)
 
     if config.allow_origins is not None:
@@ -186,5 +341,7 @@ def create_app() -> FastAPI:
         )
 
     app.add_middleware(RequestIDMiddleware)
+    # Outermost: short-circuit new requests to 503 once shutting_down is set.
+    app.add_middleware(GracefulShutdownMiddleware, app_state=app.state)
 
     return app

--- a/src/whisperx_api_server/observability/http.py
+++ b/src/whisperx_api_server/observability/http.py
@@ -9,10 +9,40 @@ from starlette.types import ASGIApp, Scope, Receive, Send
 EXCLUDED_PATHS: frozenset[str] = frozenset({"/metrics"})
 
 ERROR_TYPE_MAP: dict[int, str] = {
+    400: "bad_request",
+    401: "unauthorized",
+    403: "forbidden",
+    404: "not_found",
+    413: "payload_too_large",
+    422: "invalid_audio",
+    500: "pipeline_error",
     503: "queue_full",
     504: "timeout",
-    500: "pipeline_error",
 }
+
+# Static allowlist used as the `endpoint` label for the in-flight gauge.
+# Any path not in this set is normalized to "other" so unbounded paths
+# (typos, scanners, future routes) cannot grow Prometheus cardinality.
+KNOWN_INFLIGHT_PATHS: frozenset[str] = frozenset(
+    {
+        "/healthcheck",
+        "/v1/audio/transcriptions",
+        "/v1/audio/translations",
+        "/models/list",
+        "/models/load",
+        "/models/unload",
+        "/align_models/list",
+        "/align_models/load",
+        "/align_models/unload",
+        "/diarize_models/list",
+        "/diarize_models/load",
+        "/diarize_models/unload",
+    }
+)
+
+
+def _inflight_label(path: str) -> str:
+    return path if path in KNOWN_INFLIGHT_PATHS else "other"
 
 
 class _NoOpHistogram:
@@ -93,6 +123,7 @@ class MetricsMiddleware:
         # has replaced the singletons.
         from whisperx_api_server.observability import http as _http
 
+        inflight_label: str = _inflight_label(path)
         start_time = time.perf_counter()
         status_holder: list[int] = []
 
@@ -103,7 +134,7 @@ class MetricsMiddleware:
                 status_holder.append(message["status"])
             await send(message)
 
-        _http.requests_in_flight.labels(endpoint=path).inc()
+        _http.requests_in_flight.labels(endpoint=inflight_label).inc()
         try:
             await self.app(scope, receive, wrapped_send)
         finally:
@@ -114,7 +145,7 @@ class MetricsMiddleware:
             sc_class = f"{sc // 100}xx"
             method: str = scope.get("method", "")
 
-            _http.requests_in_flight.labels(endpoint=path).dec()
+            _http.requests_in_flight.labels(endpoint=inflight_label).dec()
             _http.requests_total.labels(
                 endpoint=endpoint, method=method, status_code=str(sc)
             ).inc()

--- a/src/whisperx_api_server/observability/registry.py
+++ b/src/whisperx_api_server/observability/registry.py
@@ -67,7 +67,10 @@ def _setup_pipeline_instruments(registry: "CollectorRegistry") -> None:
     """Construct real pipeline Histograms and replace pipeline.py shims in-place."""
     from prometheus_client import Histogram
     from whisperx_api_server.observability import pipeline as _pipe
-    from whisperx_api_server.observability.taxonomy import PIPELINE_BUCKETS
+    from whisperx_api_server.observability.taxonomy import (
+        PIPELINE_BUCKETS,
+        SEMAPHORE_BUCKETS,
+    )
 
     _pipe.stage_duration = Histogram(
         "whisperx_stage_duration_seconds",
@@ -80,7 +83,7 @@ def _setup_pipeline_instruments(registry: "CollectorRegistry") -> None:
         "whisperx_semaphore_wait_seconds",
         "Time to acquire the GPU concurrency semaphore in seconds",
         labelnames=[],
-        buckets=PIPELINE_BUCKETS,
+        buckets=SEMAPHORE_BUCKETS,
         registry=registry,
     )
     _pipe.realtime_factor = Histogram(

--- a/src/whisperx_api_server/observability/taxonomy.py
+++ b/src/whisperx_api_server/observability/taxonomy.py
@@ -22,3 +22,9 @@ class ErrorType(str, Enum):
 PIPELINE_BUCKETS: list[float] = [1, 5, 10, 30, 60, 120, 300, 600]
 HTTP_BUCKETS: list[float] = [0.1, 0.5, 1.0,
                              2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0]
+# Semaphore acquisition waits are typically sub-second when the GPU is idle
+# and grow into multi-minute territory only under sustained backpressure;
+# PIPELINE_BUCKETS bottoms out at 1s and hides the fast path entirely.
+SEMAPHORE_BUCKETS: list[float] = [
+    0.001, 0.01, 0.1, 0.5, 1, 5, 10, 30, 60, 120, 300,
+]

--- a/src/whisperx_api_server/routers/models.py
+++ b/src/whisperx_api_server/routers/models.py
@@ -1,5 +1,5 @@
 import logging
-from fastapi import APIRouter, Form
+from fastapi import APIRouter, Form, HTTPException, status
 from fastapi.responses import JSONResponse
 from typing import Annotated
 from pydantic import AfterValidator
@@ -48,7 +48,11 @@ def list_models_endpoint():
         models = backend.list_loaded_models()
         return JSONResponse(content={"models": models}, media_type=MediaType.APPLICATION_JSON)
     except Exception as e:
-        return JSONResponse(content={"status": "error", "message": str(e)}, media_type=MediaType.APPLICATION_JSON)
+        logger.exception("Failed to list transcription models")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(e),
+        ) from e
 
 
 @router.post(
@@ -56,17 +60,27 @@ def list_models_endpoint():
     description="Unload a model",
     tags=["models", "transcribe"],
 )
-def unload_model_endpoint(model: Annotated[ModelName, Form()]):
+async def unload_model_endpoint(model: Annotated[ModelName, Form()]):
     logger.info(f"Received request to unload model {model}")
     try:
         selected_backends = resolve_stage_backends()
         backend = get_transcription_backend(selected_backends.transcription)
-        unloaded = backend.unload_model(model)
-        response_data = {"status": "success"} if unloaded else {
-            "status": "error", "message": f"Model {model} not found"}
-        return JSONResponse(content=response_data, media_type=MediaType.APPLICATION_JSON)
+        unloaded = await backend.unload_model(model)
     except Exception as e:
-        return JSONResponse(content={"status": "error", "message": str(e)}, media_type=MediaType.APPLICATION_JSON)
+        logger.exception("Failed to unload transcription model %s", model)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(e),
+        ) from e
+    if not unloaded:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Model {model} not found",
+        )
+    return JSONResponse(
+        content={"status": "success"},
+        media_type=MediaType.APPLICATION_JSON,
+    )
 
 
 @router.post(
@@ -84,7 +98,11 @@ async def load_model(model: Annotated[ModelName, Form()]):
         await backend.load_model(model_name=model)
         return JSONResponse(content={"status": "success", "model": model}, media_type=MediaType.APPLICATION_JSON)
     except Exception as e:
-        return JSONResponse(content={"status": "error", "message": str(e)}, media_type=MediaType.APPLICATION_JSON)
+        logger.exception("Failed to load transcription model %s", model)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(e),
+        ) from e
 
 
 @router.get(
@@ -98,7 +116,11 @@ def list_align_models_endpoint():
         backend = get_alignment_backend(selected_backends.alignment)
         return JSONResponse(content={"models": backend.list_loaded_models()}, media_type=MediaType.APPLICATION_JSON)
     except Exception as e:
-        return JSONResponse(content={"status": "error", "message": str(e)}, media_type=MediaType.APPLICATION_JSON)
+        logger.exception("Failed to list alignment models")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(e),
+        ) from e
 
 
 @router.post(
@@ -106,18 +128,28 @@ def list_align_models_endpoint():
     description="Unload an align model",
     tags=["models", "align"],
 )
-def unload_align_model_endpoint(language: Annotated[Language, Form()]):
+async def unload_align_model_endpoint(language: Annotated[Language, Form()]):
     logger.info(f"Received request to unload align model {language}")
+    language_code = getattr(language, "value", language)
     try:
         selected_backends = resolve_stage_backends()
         backend = get_alignment_backend(selected_backends.alignment)
-        language_code = getattr(language, "value", language)
-        unloaded = backend.unload_model(str(language_code))
-        response_data = {"status": "success"} if unloaded else {
-            "status": "error", "message": f"Model with language {language_code} not found"}
-        return JSONResponse(content=response_data, media_type=MediaType.APPLICATION_JSON)
+        unloaded = await backend.unload_model(str(language_code))
     except Exception as e:
-        return JSONResponse(content={"status": "error", "message": str(e)}, media_type=MediaType.APPLICATION_JSON)
+        logger.exception("Failed to unload align model %s", language_code)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(e),
+        ) from e
+    if not unloaded:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Model with language {language_code} not found",
+        )
+    return JSONResponse(
+        content={"status": "success"},
+        media_type=MediaType.APPLICATION_JSON,
+    )
 
 
 @router.post(
@@ -127,16 +159,20 @@ def unload_align_model_endpoint(language: Annotated[Language, Form()]):
 )
 async def load_alignment_endpoint(language: Annotated[Language, Form()]):
     logger.info(f"Received request to load align model {language}")
+    language_code = str(getattr(language, "value", language))
     try:
         selected_backends = resolve_stage_backends()
         backend = get_alignment_backend(selected_backends.alignment)
-        language_code = str(getattr(language, "value", language))
         if language_code in backend.list_loaded_models():
             return JSONResponse(content={"status": "success", "model": language_code}, media_type=MediaType.APPLICATION_JSON)
         await backend.load_model(language_code)
         return JSONResponse(content={"status": "success", "model": language_code}, media_type=MediaType.APPLICATION_JSON)
     except Exception as e:
-        return JSONResponse(content={"status": "error", "message": str(e)}, media_type=MediaType.APPLICATION_JSON)
+        logger.exception("Failed to load align model %s", language_code)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(e),
+        ) from e
 
 
 @router.get(
@@ -150,7 +186,11 @@ def list_diarize_models_endpoint():
         backend = get_diarization_backend(selected_backends.diarization)
         return JSONResponse(content={"models": backend.list_loaded_models()}, media_type=MediaType.APPLICATION_JSON)
     except Exception as e:
-        return JSONResponse(content={"status": "error", "message": str(e)}, media_type=MediaType.APPLICATION_JSON)
+        logger.exception("Failed to list diarization models")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(e),
+        ) from e
 
 
 @router.post(
@@ -158,17 +198,27 @@ def list_diarize_models_endpoint():
     description="Unload a diarize model",
     tags=["models", "diarize"],
 )
-def unload_diarize_model(model: Annotated[ModelName, Form()]):
+async def unload_diarize_model(model: Annotated[ModelName, Form()]):
     logger.info(f"Received request to unload diarize model {model}")
     try:
         selected_backends = resolve_stage_backends()
         backend = get_diarization_backend(selected_backends.diarization)
-        unloaded = backend.unload_model(model)
-        response_data = {"status": "success"} if unloaded else {
-            "status": "error", "message": f"Model {model} not found"}
-        return JSONResponse(content=response_data, media_type=MediaType.APPLICATION_JSON)
+        unloaded = await backend.unload_model(model)
     except Exception as e:
-        return JSONResponse(content={"status": "error", "message": str(e)}, media_type=MediaType.APPLICATION_JSON)
+        logger.exception("Failed to unload diarize model %s", model)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(e),
+        ) from e
+    if not unloaded:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Model {model} not found",
+        )
+    return JSONResponse(
+        content={"status": "success"},
+        media_type=MediaType.APPLICATION_JSON,
+    )
 
 
 @router.post(
@@ -186,4 +236,8 @@ async def load_diarization_endpoint(model: Annotated[ModelName, Form()]):
         await backend.load_model(model_name=model)
         return JSONResponse(content={"status": "success", "model": model}, media_type=MediaType.APPLICATION_JSON)
     except Exception as e:
-        return JSONResponse(content={"status": "error", "message": str(e)}, media_type=MediaType.APPLICATION_JSON)
+        logger.exception("Failed to load diarize model %s", model)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(e),
+        ) from e

--- a/src/whisperx_api_server/routers/transcriptions.py
+++ b/src/whisperx_api_server/routers/transcriptions.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from .models import handle_default_openai_model
 from fastapi import (
@@ -15,7 +16,11 @@ import time
 
 
 import whisperx_api_server.transcriber as transcriber
-from whisperx_api_server.transcriber import QueueFullError
+from whisperx_api_server.transcriber import (
+    InvalidAudioError,
+    QueueFullError,
+    UploadTooLargeError,
+)
 from whisperx_api_server.dependencies import get_config
 from whisperx_api_server.formatters import format_transcription
 from whisperx_api_server.backends.registry import (
@@ -26,6 +31,42 @@ from whisperx_api_server.config import (
     Language,
     ResponseFormat,
 )
+
+try:
+    import torch as _torch
+    _CUDA_OOM_EXC: type[BaseException] = _torch.cuda.OutOfMemoryError
+except Exception:  # torch missing or no CUDA build
+    _CUDA_OOM_EXC = RuntimeError  # benign fallback; isinstance still works
+
+
+def _raise_for_transcription_error(request_id: str, e: Exception, kind: str) -> None:
+    """Map domain exceptions to specific HTTP codes; fall through to 500."""
+    if isinstance(e, InvalidAudioError):
+        logger.info(f"Request ID: {request_id} - Invalid audio: {e}")
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)) from e
+    if isinstance(e, UploadTooLargeError):
+        logger.info(f"Request ID: {request_id} - Upload too large: {e}")
+        raise HTTPException(status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE, detail=str(e)) from e
+    if isinstance(e, QueueFullError):
+        logger.warning(f"Request ID: {request_id} - Queue full: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Server is busy, please try again later.",
+        ) from e
+    if isinstance(e, asyncio.TimeoutError) or isinstance(e, TimeoutError):
+        logger.warning(f"Request ID: {request_id} - Timeout: {e}")
+        raise HTTPException(status_code=status.HTTP_504_GATEWAY_TIMEOUT, detail=str(e)) from e
+    if isinstance(e, _CUDA_OOM_EXC) and "out of memory" in str(e).lower():
+        logger.error(f"Request ID: {request_id} - CUDA OOM: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Out of GPU memory; retry shortly.",
+        ) from e
+    logger.exception(f"Request ID: {request_id} - {kind} failed: {e}")
+    raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail=f"An unexpected error occurred while processing the {kind} request.",
+    ) from e
 
 logger = logging.getLogger(__name__)
 
@@ -185,19 +226,11 @@ async def transcribe_audio(
                 chunk_size=chunk_size,
                 request_id=request_id,
             )
-    except QueueFullError as e:
-        logger.warning(f"Request ID: {request_id} - Queue full: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Server is busy, please try again later."
-        ) from e
+    except asyncio.CancelledError:
+        logger.info(f"Request ID: {request_id} - Client disconnected; cancelling")
+        raise
     except Exception as e:
-        logger.exception(
-            f"Request ID: {request_id} - Transcription failed: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="An unexpected error occurred while processing the transcription request."
-        ) from e
+        _raise_for_transcription_error(request_id, e, "transcription")
 
     total_time = time.time() - start_time
     logger.info(
@@ -281,18 +314,11 @@ async def translate_audio(
                 request_id=request_id,
                 task="translate",
             )
-    except QueueFullError as e:
-        logger.warning(f"Request ID: {request_id} - Queue full: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Server is busy, please try again later."
-        ) from e
+    except asyncio.CancelledError:
+        logger.info(f"Request ID: {request_id} - Client disconnected; cancelling")
+        raise
     except Exception as e:
-        logger.exception(f"Request ID: {request_id} - Translation failed: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="An unexpected error occurred while processing the translation request."
-        ) from e
+        _raise_for_transcription_error(request_id, e, "translation")
 
     total_time = time.time() - start_time
     logger.info(

--- a/src/whisperx_api_server/s3_client.py
+++ b/src/whisperx_api_server/s3_client.py
@@ -19,6 +19,7 @@ async def init_client(cfg: S3Config) -> None:
     from aiobotocore.session import AioSession
 
     _config = cfg
+    from botocore.config import Config as BotocoreConfig
     session = AioSession()
     ctx = session.create_client(
         "s3",
@@ -26,6 +27,11 @@ async def init_client(cfg: S3Config) -> None:
         endpoint_url=cfg.endpoint_url,
         aws_access_key_id=cfg.access_key_id,
         aws_secret_access_key=cfg.secret_access_key,
+        config=BotocoreConfig(
+            retries={"max_attempts": 5, "mode": "adaptive"},
+            connect_timeout=10,
+            read_timeout=120,
+        ),
     )
     _client = await ctx.__aenter__()
     logger.info(
@@ -41,7 +47,7 @@ async def init_client(cfg: S3Config) -> None:
             await _client.create_bucket(Bucket=cfg.bucket)
             logger.info(f"Created S3 bucket: {cfg.bucket}")
 
-        if cfg.object_expiry_days > 0:
+        if cfg.manage_lifecycle and cfg.object_expiry_days > 0:
             await _client.put_bucket_lifecycle_configuration(
                 Bucket=cfg.bucket,
                 LifecycleConfiguration={
@@ -80,6 +86,15 @@ async def upload_audio(data: bytes, job_id: str, filename: str) -> str:
     key = f"audio/{job_id}/{filename}"
     await _client.put_object(Bucket=_config.bucket, Key=key, Body=data)
     logger.debug(f"Uploaded {len(data)} bytes to s3://{_config.bucket}/{key}")
+    return key
+
+
+async def upload_audio_stream(fileobj, job_id: str, filename: str) -> str:
+    if _client is None or _config is None:
+        raise RuntimeError("S3 client not initialized")
+    key = f"audio/{job_id}/{filename}"
+    await _client.put_object(Bucket=_config.bucket, Key=key, Body=fileobj)
+    logger.debug(f"Uploaded stream to s3://{_config.bucket}/{key}")
     return key
 
 

--- a/src/whisperx_api_server/transcriber.py
+++ b/src/whisperx_api_server/transcriber.py
@@ -1,11 +1,11 @@
 import contextlib
 import os
 import queue
+import re
 import threading
 from typing import Any
 
 import numpy as np
-import torch
 import gc
 import logging
 import time
@@ -33,33 +33,68 @@ logger = logging.getLogger(__name__)
 
 config = get_config()
 
-_concurrency_semaphore = None
+_concurrency_semaphore: asyncio.Semaphore | None = None
+_decode_semaphore: asyncio.Semaphore | None = None
 _UPLOAD_STREAM_CHUNK_SIZE = 1024 * 1024  # 1 MiB
 _UPLOAD_WRITE_BUFFER_SIZE = 1024 * 1024  # 1 MiB
+_UPLOAD_WRITER_JOIN_TIMEOUT_SECS = 10  # writer thread should drain in <1s on healthy disk
+_FILENAME_SAFE_CHARS = re.compile(r"[^A-Za-z0-9._-]")
+_FILENAME_MAX_SUFFIX_LEN = 64
+
+
+class InvalidAudioError(ValueError):
+    """The upload could not be decoded as audio — treat as HTTP 422 (client error)."""
+
+
+class UploadTooLargeError(ValueError):
+    """The upload exceeded max_upload_size_bytes — treat as HTTP 413 (client error)."""
+
+
+def _safe_filename(filename: str | None, default: str = "audio") -> str:
+    """Return a sanitized filename. Strips path components and non-word chars
+    so a malicious or unusual filename cannot break tempfile paths or S3 keys.
+    Returns `default` if nothing usable is left."""
+    if not filename:
+        return default
+    base = os.path.basename(filename)
+    safe = _FILENAME_SAFE_CHARS.sub("_", base)[:_FILENAME_MAX_SUFFIX_LEN]
+    return safe or default
+
+
+def _safe_filename_suffix(filename: str | None) -> str:
+    """Return a sanitized suffix for tempfile naming."""
+    safe = _safe_filename(filename, default="")
+    return f"_{safe}" if safe else ""
+
+
+def init_concurrency() -> None:
+    """Eagerly create the inference and decode-admission semaphores. Called once from lifespan."""
+    global _concurrency_semaphore, _decode_semaphore
+    n = config.max_concurrent_transcriptions
+    _concurrency_semaphore = asyncio.Semaphore(n) if n > 0 else None
+    # Decode admission: allows one more concurrent decode than inference slots so a new
+    # request can decode while the previous one is still on the model executor.
+    d = n + 1 if n > 0 else 0
+    _decode_semaphore = asyncio.Semaphore(d) if d > 0 else None
 
 
 def _get_concurrency_semaphore() -> asyncio.Semaphore | None:
-    global _concurrency_semaphore
-    if not torch.cuda.is_available():
-        return None
-    if _concurrency_semaphore is None:
-        _concurrency_semaphore = asyncio.Semaphore(
-            config.max_concurrent_transcriptions)
     return _concurrency_semaphore
+
+
+def _get_decode_semaphore() -> asyncio.Semaphore | None:
+    return _decode_semaphore
 
 
 def _cleanup_cache_only():
     gc.collect()
-
-    if torch.cuda.is_available():
-        torch.cuda.empty_cache()
 
 
 _SAMPLE_RATE = 16000  # matches whisperx.audio.SAMPLE_RATE
 
 
 def _ffmpeg_decode_cmd(input_arg: str, sample_rate: int) -> list[str]:
-    cmd = ["ffmpeg", "-threads", "0"]
+    cmd = ["ffmpeg", "-hide_banner", "-loglevel", "error", "-threads", "0"]
     if input_arg != "pipe:0":
         cmd.append("-nostdin")
     cmd += ["-i", input_arg, "-f", "f32le", "-ac", "1", "-ar", str(sample_rate), "pipe:1"]
@@ -106,10 +141,14 @@ async def _run_ffmpeg_decode(
     rc = await proc.wait()
     if rc != 0:
         msg = err.decode(errors="replace").strip()
-        logger.error(f"Request ID: {request_id} - ffmpeg exited {rc}: {msg}")
-        raise RuntimeError(f"ffmpeg failed (exit {rc}): {msg}")
+        logger.warning(f"Request ID: {request_id} - ffmpeg exited {rc}: {msg}")
+        raise InvalidAudioError(f"Could not decode audio (ffmpeg exit {rc}): {msg}")
 
     audio = np.frombuffer(pcm, dtype=np.float32).copy()
+    if audio.size == 0:
+        raise InvalidAudioError(
+            "Decoded audio is empty (no audio stream or zero-length input)."
+        )
     logger.info(
         f"Request ID: {request_id} - Audio decoded "
         f"({audio.size} samples, {audio.size / sample_rate:.2f}s)"
@@ -137,8 +176,10 @@ async def load_audio_from_bytes(
 
 
 async def _save_upload_to_temp(audio_file: UploadFile, request_id: str) -> str:
-    """Stream upload to temp file in chunks"""
-    with tempfile.NamedTemporaryFile(delete=False, suffix=f"_{audio_file.filename}") as tmp:
+    """Stream upload to temp file in chunks. Enforces max_upload_size_bytes if set."""
+    max_bytes = config.max_upload_size_bytes
+    suffix = _safe_filename_suffix(audio_file.filename)
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
         file_path = tmp.name
 
     chunk_queue: queue.Queue[bytes | None] = queue.Queue(maxsize=2)
@@ -158,27 +199,32 @@ async def _save_upload_to_temp(audio_file: UploadFile, request_id: str) -> str:
     writer_thread = threading.Thread(target=_writer, daemon=True)
     writer_thread.start()
 
+    total_bytes = 0
     try:
         while True:
             chunk = await audio_file.read(_UPLOAD_STREAM_CHUNK_SIZE)
             if len(chunk) == 0:
                 break
+            total_bytes += len(chunk)
+            if max_bytes > 0 and total_bytes > max_bytes:
+                raise UploadTooLargeError(
+                    f"Upload exceeds max_upload_size_bytes ({max_bytes} bytes)."
+                )
             try:
                 chunk_queue.put_nowait(chunk)
             except queue.Full:
                 await asyncio.to_thread(chunk_queue.put, chunk)
-            if len(chunk) < _UPLOAD_STREAM_CHUNK_SIZE:
-                break
         try:
             chunk_queue.put_nowait(None)
         except queue.Full:
             await asyncio.to_thread(chunk_queue.put, None)
     except Exception as e:
-        logger.error(
-            f"Request ID: {request_id} - Failed to read uploaded file: {e}")
+        if not isinstance(e, UploadTooLargeError):
+            logger.error(
+                f"Request ID: {request_id} - Failed to read uploaded file: {e}")
         with contextlib.suppress(queue.Full):
             chunk_queue.put_nowait(None)
-        await asyncio.to_thread(writer_thread.join, 5)
+        await asyncio.to_thread(writer_thread.join, _UPLOAD_WRITER_JOIN_TIMEOUT_SECS)
         if os.path.exists(file_path):
             try:
                 os.remove(file_path)
@@ -186,7 +232,7 @@ async def _save_upload_to_temp(audio_file: UploadFile, request_id: str) -> str:
                 pass
         raise
     finally:
-        await asyncio.to_thread(writer_thread.join, 30)
+        await asyncio.to_thread(writer_thread.join, _UPLOAD_WRITER_JOIN_TIMEOUT_SECS)
 
     if write_error:
         if os.path.exists(file_path):
@@ -228,8 +274,9 @@ async def transcribe(
     file_path = None
     audio = None
     concurrency_sem = _get_concurrency_semaphore()
-    semaphore_acquired = False
+    decode_sem = _get_decode_semaphore()
     profile: dict[str, float] = {}
+    audio_duration_seconds = 0.0
 
     try:
         t0 = time.perf_counter()
@@ -240,16 +287,26 @@ async def transcribe(
         _pipe.stage_duration.labels(
             stage="upload_save").observe(profile["upload_save"])
 
-        if concurrency_sem:
-            _sem_t0 = time.perf_counter()
-            await concurrency_sem.acquire()
-            semaphore_acquired = True
-            _sem_elapsed = time.perf_counter() - _sem_t0
-            logger.debug(
-                f"Request ID: {request_id} - Acquired GPU concurrency semaphore")
-        else:
-            _sem_elapsed = 0.0
-        _pipe.semaphore_wait.observe(_sem_elapsed)
+        # Decode outside the inference semaphore, bounded by the decode-admission semaphore.
+        async with contextlib.AsyncExitStack() as _decode_stack:
+            if decode_sem is not None:
+                await _decode_stack.enter_async_context(decode_sem)
+            t0 = time.perf_counter()
+            audio = await load_audio_from_path(file_path, request_id)
+            profile["audio_load"] = time.perf_counter() - t0
+            logger.info(
+                f"Request ID: {request_id} - Loading audio took {profile['audio_load']:.2f} seconds")
+            _pipe.stage_duration.labels(
+                stage="audio_load").observe(profile["audio_load"])
+            audio_duration_seconds = len(audio) / 16000.0
+
+            if file_path and os.path.exists(file_path):
+                try:
+                    os.remove(file_path)
+                except OSError:
+                    pass
+                file_path = None
+        # decode_sem released; temp file deleted; float32 array in memory
 
         selected_backends = resolve_stage_backends()
         transcription_stage_backend = get_transcription_backend(
@@ -271,100 +328,96 @@ async def transcribe(
         logger.info(
             f"Request ID: {request_id} - Transcribing {audio_file.filename} with model: {model_name}, options: {asr_options}, language: {language}, task: {task}, stage_backends: {selected_backends}")
 
-        t0 = time.perf_counter()
-        audio = await load_audio_from_path(file_path, request_id)
-        profile["audio_load"] = time.perf_counter() - t0
-        logger.info(
-            f"Request ID: {request_id} - Loading audio took {profile['audio_load']:.2f} seconds")
-        _pipe.stage_duration.labels(
-            stage="audio_load").observe(profile["audio_load"])
-        audio_duration_seconds = len(audio) / 16000.0
-
-        if file_path and os.path.exists(file_path):
-            try:
-                os.remove(file_path)
-            except OSError:
-                pass
-            file_path = None
-
-        t0 = time.perf_counter()
-        result = await transcription_stage_backend.transcribe(
-            model_name=model_name,
-            audio=audio,
-            batch_size=batch_size,
-            chunk_size=chunk_size,
-            language=language,
-            task=task,
-            asr_options=asr_options,
-            request_id=request_id,
-        )
-        profile["transcribe"] = time.perf_counter() - t0
-        logger.info(
-            f"Request ID: {request_id} - Transcription took {profile['transcribe']:.2f} seconds")
-        _pipe.stage_duration.labels(
-            stage="transcribe").observe(profile["transcribe"])
-        _pipe.realtime_factor.labels(model=model_name, stage="transcribe").observe(
-            profile["transcribe"] / audio_duration_seconds
-        )
-
-        if align or diarize:
-            if alignment_stage_backend is None:
-                raise RuntimeError("Alignment backend is not initialized.")
-            t0 = time.perf_counter()
-            result = await alignment_stage_backend.align(
-                result=result,
-                audio=audio,
-                request_id=request_id,
-            )
-            profile["align"] = time.perf_counter() - t0
-            logger.debug(
-                f"Request ID: {request_id} - Alignment took {profile['align']:.2f} seconds")
-            _pipe.stage_duration.labels(
-                stage="align").observe(profile["align"])
-            _pipe.realtime_factor.labels(model=model_name, stage="align").observe(
-                profile["align"] / audio_duration_seconds
-            )
-
-        if diarize:
-            if diarization_stage_backend is None:
-                raise RuntimeError("Diarization backend is not initialized.")
-            t0 = time.perf_counter()
-            result = await diarization_stage_backend.diarize(
-                result=result,
-                audio=audio,
-                speaker_embeddings=speaker_embeddings,
-                request_id=request_id,
-            )
-            profile["diarize"] = time.perf_counter() - t0
-            logger.debug(
-                f"Request ID: {request_id} - Diarization took {profile['diarize']:.2f} seconds")
-            _pipe.stage_duration.labels(
-                stage="diarize").observe(profile["diarize"])
-            _pipe.realtime_factor.labels(model=model_name, stage="diarize").observe(
-                profile["diarize"] / audio_duration_seconds
-            )
-
-        t0 = time.perf_counter()
-        result = _finalize_text(result, align or diarize)
-        profile["finalize"] = time.perf_counter() - t0
-
-        total = time.perf_counter() - start_time
-        logger.info(
-            f"Request ID: {request_id} - Transcription completed for {audio_file.filename}")
+        _sem_t0 = time.perf_counter()
+        if concurrency_sem:
+            await concurrency_sem.acquire()
+        _sem_elapsed = time.perf_counter() - _sem_t0
         logger.debug(
-            f"Request ID: {request_id} - profile: total={total:.2f}s | "
-            + " | ".join(f"{k}={v:.2f}s" for k, v in profile.items())
-            + f" | (other={total - sum(profile.values()):.2f}s)")
+            f"Request ID: {request_id} - Acquired inference concurrency semaphore")
+        _pipe.semaphore_wait.observe(_sem_elapsed)
 
-        return result
+        try:
+            t0 = time.perf_counter()
+            result = await transcription_stage_backend.transcribe(
+                model_name=model_name,
+                audio=audio,
+                batch_size=batch_size,
+                chunk_size=chunk_size,
+                language=language,
+                task=task,
+                asr_options=asr_options,
+                request_id=request_id,
+            )
+            profile["transcribe"] = time.perf_counter() - t0
+            logger.info(
+                f"Request ID: {request_id} - Transcription took {profile['transcribe']:.2f} seconds")
+            _pipe.stage_duration.labels(
+                stage="transcribe").observe(profile["transcribe"])
+            if audio_duration_seconds > 0:
+                _pipe.realtime_factor.labels(model=model_name, stage="transcribe").observe(
+                    profile["transcribe"] / audio_duration_seconds
+                )
+
+            if align or diarize:
+                if alignment_stage_backend is None:
+                    raise RuntimeError("Alignment backend is not initialized.")
+                t0 = time.perf_counter()
+                result = await alignment_stage_backend.align(
+                    result=result,
+                    audio=audio,
+                    request_id=request_id,
+                )
+                profile["align"] = time.perf_counter() - t0
+                logger.debug(
+                    f"Request ID: {request_id} - Alignment took {profile['align']:.2f} seconds")
+                _pipe.stage_duration.labels(
+                    stage="align").observe(profile["align"])
+                if audio_duration_seconds > 0:
+                    _pipe.realtime_factor.labels(model=model_name, stage="align").observe(
+                        profile["align"] / audio_duration_seconds
+                    )
+
+            if diarize:
+                if diarization_stage_backend is None:
+                    raise RuntimeError("Diarization backend is not initialized.")
+                t0 = time.perf_counter()
+                result = await diarization_stage_backend.diarize(
+                    result=result,
+                    audio=audio,
+                    speaker_embeddings=speaker_embeddings,
+                    request_id=request_id,
+                )
+                profile["diarize"] = time.perf_counter() - t0
+                logger.debug(
+                    f"Request ID: {request_id} - Diarization took {profile['diarize']:.2f} seconds")
+                _pipe.stage_duration.labels(
+                    stage="diarize").observe(profile["diarize"])
+                if audio_duration_seconds > 0:
+                    _pipe.realtime_factor.labels(model=model_name, stage="diarize").observe(
+                        profile["diarize"] / audio_duration_seconds
+                    )
+
+            t0 = time.perf_counter()
+            result = _finalize_text(result, align or diarize)
+            profile["finalize"] = time.perf_counter() - t0
+
+            total = time.perf_counter() - start_time
+            logger.info(
+                f"Request ID: {request_id} - Transcription completed for {audio_file.filename}")
+            logger.debug(
+                f"Request ID: {request_id} - profile: total={total:.2f}s | "
+                + " | ".join(f"{k}={v:.2f}s" for k, v in profile.items())
+                + f" | (other={total - sum(profile.values()):.2f}s)")
+
+            return result
+        finally:
+            if concurrency_sem:
+                concurrency_sem.release()
     except Exception as e:
         logger.error(
             f"Request ID: {request_id} - Transcription failed for {audio_file.filename} with error: {e}")
         raise
     finally:
-        with contextlib.suppress(Exception):
-            if concurrency_sem and semaphore_acquired:
-                concurrency_sem.release()
         with contextlib.suppress(Exception):
             if file_path is not None and os.path.exists(file_path):
                 os.remove(file_path)
@@ -393,14 +446,13 @@ async def transcribe_via_kafka(
             f"Too many pending jobs ({len(kafka_client._pending_jobs)}/{max_pending})"
         )
 
+    safe_name = _safe_filename(audio_file.filename)
     logger.info(f"Request ID: {request_id} - Uploading audio to S3")
-    audio_bytes = await audio_file.read()
-    s3_key = await s3_client.upload_audio(audio_bytes, request_id, audio_file.filename or "audio")
-    del audio_bytes
+    s3_key = await s3_client.upload_audio_stream(audio_file.file, request_id, safe_name)
 
     logger.info(
         f"Request ID: {request_id} - Submitting job to Kafka (key: {s3_key})")
-    future = await kafka_client.submit_job(request_id, s3_key, audio_file.filename or "audio", params)
+    future = await kafka_client.submit_job(request_id, s3_key, safe_name, params)
     try:
         result = await asyncio.wait_for(future, timeout=config.kafka.reply_timeout_seconds)
         logger.info(f"Request ID: {request_id} - Received result from worker")
@@ -413,3 +465,6 @@ async def transcribe_via_kafka(
         raise TimeoutError(
             f"Job {request_id} timed out after {config.kafka.reply_timeout_seconds}s"
         )
+    except BaseException:
+        kafka_client._pending_jobs.pop(request_id, None)
+        raise

--- a/src/whisperx_api_server/transcriber.py
+++ b/src/whisperx_api_server/transcriber.py
@@ -2,7 +2,6 @@ import contextlib
 import os
 import queue
 import threading
-from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 import numpy as np
@@ -13,8 +12,6 @@ import time
 import tempfile
 import asyncio
 from fastapi import UploadFile
-
-from whisperx import audio as whisperx_audio
 
 from whisperx_api_server.config import (
     Language,
@@ -37,7 +34,6 @@ logger = logging.getLogger(__name__)
 config = get_config()
 
 _concurrency_semaphore = None
-_io_executor: ThreadPoolExecutor | None = None
 _UPLOAD_STREAM_CHUNK_SIZE = 1024 * 1024  # 1 MiB
 _UPLOAD_WRITE_BUFFER_SIZE = 1024 * 1024  # 1 MiB
 
@@ -59,12 +55,85 @@ def _cleanup_cache_only():
         torch.cuda.empty_cache()
 
 
-def _get_io_executor() -> ThreadPoolExecutor:
-    global _io_executor
-    if _io_executor is None:
-        _io_executor = ThreadPoolExecutor(
-            max_workers=config.io_executor_workers, thread_name_prefix="whisperx_io")
-    return _io_executor
+_SAMPLE_RATE = 16000  # matches whisperx.audio.SAMPLE_RATE
+
+
+def _ffmpeg_decode_cmd(input_arg: str, sample_rate: int) -> list[str]:
+    cmd = ["ffmpeg", "-threads", "0"]
+    if input_arg != "pipe:0":
+        cmd.append("-nostdin")
+    cmd += ["-i", input_arg, "-f", "f32le", "-ac", "1", "-ar", str(sample_rate), "pipe:1"]
+    return cmd
+
+
+async def _run_ffmpeg_decode(
+    input_arg: str,
+    feed_stdin,
+    request_id: str,
+    sample_rate: int,
+) -> np.ndarray:
+    proc = await asyncio.create_subprocess_exec(
+        *_ffmpeg_decode_cmd(input_arg, sample_rate),
+        stdin=asyncio.subprocess.PIPE if feed_stdin else asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    async def _pump_stdin():
+        if feed_stdin is None:
+            return
+        try:
+            await feed_stdin(proc.stdin)
+        except (BrokenPipeError, ConnectionResetError):
+            pass  # ffmpeg died early; stderr reader will surface the real reason
+        finally:
+            try:
+                proc.stdin.close()
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+
+    try:
+        _, pcm, err = await asyncio.gather(
+            _pump_stdin(),
+            proc.stdout.read(),
+            proc.stderr.read(),
+        )
+    except BaseException:
+        proc.kill()
+        await proc.wait()
+        raise
+
+    rc = await proc.wait()
+    if rc != 0:
+        msg = err.decode(errors="replace").strip()
+        logger.error(f"Request ID: {request_id} - ffmpeg exited {rc}: {msg}")
+        raise RuntimeError(f"ffmpeg failed (exit {rc}): {msg}")
+
+    audio = np.frombuffer(pcm, dtype=np.float32).copy()
+    logger.info(
+        f"Request ID: {request_id} - Audio decoded "
+        f"({audio.size} samples, {audio.size / sample_rate:.2f}s)"
+    )
+    return audio
+
+
+async def load_audio_from_path(
+    file_path: str,
+    request_id: str,
+    sample_rate: int = _SAMPLE_RATE,
+) -> np.ndarray:
+    return await _run_ffmpeg_decode(file_path, None, request_id, sample_rate)
+
+
+async def load_audio_from_bytes(
+    audio_bytes: bytes,
+    request_id: str,
+    sample_rate: int = _SAMPLE_RATE,
+) -> np.ndarray:
+    async def feed(stdin):
+        stdin.write(audio_bytes)
+        await stdin.drain()
+    return await _run_ffmpeg_decode("pipe:0", feed, request_id, sample_rate)
 
 
 async def _save_upload_to_temp(audio_file: UploadFile, request_id: str) -> str:
@@ -130,19 +199,6 @@ async def _save_upload_to_temp(audio_file: UploadFile, request_id: str) -> str:
         raise write_error[0]
 
     return file_path
-
-
-async def _load_audio(file_path: str, request_id: str) -> np.ndarray:
-    loop = asyncio.get_running_loop()
-    executor = _get_io_executor()
-    try:
-        audio = await loop.run_in_executor(executor, whisperx_audio.load_audio, file_path)
-        logger.info(
-            f"Request ID: {request_id} - Audio loaded from {file_path}")
-        return audio
-    except Exception as e:
-        logger.error(f"Request ID: {request_id} - Failed to load audio: {e}")
-        raise
 
 
 def _finalize_text(result: dict[str, Any], align_or_diarize: bool) -> dict[str, Any]:
@@ -216,7 +272,7 @@ async def transcribe(
             f"Request ID: {request_id} - Transcribing {audio_file.filename} with model: {model_name}, options: {asr_options}, language: {language}, task: {task}, stage_backends: {selected_backends}")
 
         t0 = time.perf_counter()
-        audio = await _load_audio(file_path, request_id)
+        audio = await load_audio_from_path(file_path, request_id)
         profile["audio_load"] = time.perf_counter() - t0
         logger.info(
             f"Request ID: {request_id} - Loading audio took {profile['audio_load']:.2f} seconds")

--- a/src/whisperx_worker/main.py
+++ b/src/whisperx_worker/main.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import signal
 
 from whisperx_api_server.backends.registry import (
     get_alignment_backend,
@@ -57,6 +58,30 @@ async def run_worker() -> None:
             config.metrics.worker_port,
         )
 
+    from whisperx_api_server.transcriber import init_concurrency
+    init_concurrency()
+
+    shutdown_event = asyncio.Event()
+
+    def _request_worker_shutdown(signame: str) -> None:
+        if shutdown_event.is_set():
+            return
+        shutdown_event.set()
+        logger.info(
+            "%s received — finishing current job (if any) then shutting down",
+            signame,
+        )
+
+    sigterm_registered = False
+    try:
+        loop = asyncio.get_running_loop()
+        loop.add_signal_handler(signal.SIGTERM, _request_worker_shutdown, "SIGTERM")
+        sigterm_registered = True
+    except NotImplementedError:
+        logger.info(
+            "Worker SIGTERM handler unavailable on this platform (likely Windows)"
+        )
+
     await s3_client.init_client(config.s3)
 
     selected_backends = resolve_stage_backends()
@@ -81,7 +106,6 @@ async def run_worker() -> None:
             "Failed to preload diarization backend; will load on first job")
 
     consumer = AIOKafkaConsumer(
-        config.kafka.request_topic,
         bootstrap_servers=config.kafka.bootstrap_servers,
         group_id=config.kafka.consumer_group_worker,
         enable_auto_commit=False,
@@ -93,8 +117,37 @@ async def run_worker() -> None:
         max_request_size=config.kafka.max_message_bytes,
     )
 
+    from aiokafka import ConsumerRebalanceListener
+
+    job_in_flight = [False]
+
+    class _PauseAwareRebalanceListener(ConsumerRebalanceListener):
+        """Restores `consumer.pause()` state across partition reassignments.
+
+        The worker pauses the consumer for the duration of a single job to
+        enforce one-job-at-a-time semantics. Without this listener, a Kafka
+        rebalance (broker restart, partition reassignment, etc.) silently
+        clears the paused set on the newly-assigned partitions and the
+        consumer would begin pulling fresh records mid-job.
+        """
+
+        async def on_partitions_revoked(self, revoked):
+            return
+
+        async def on_partitions_assigned(self, assigned):
+            if job_in_flight[0] and assigned:
+                consumer.pause(*assigned)
+                logger.info(
+                    "Rebalance: re-applied pause on %d partition(s) for in-flight job",
+                    len(assigned),
+                )
+
     await consumer.start()
     await producer.start()
+    consumer.subscribe(
+        topics=[config.kafka.request_topic],
+        listener=_PauseAwareRebalanceListener(),
+    )
     logger.info(
         f"Worker ready — topic: {config.kafka.request_topic}, "
         f"group: {config.kafka.consumer_group_worker}, "
@@ -102,58 +155,80 @@ async def run_worker() -> None:
     )
 
     try:
-        async for msg in consumer:
-            try:
-                event = json.loads(msg.value)
-            except Exception:
-                preview = msg.value[:200] if msg.value else b""
-                logger.error(
-                    "Failed to parse Kafka message (offset=%s, partition=%s), skipping. "
-                    "Raw value preview: %r",
-                    msg.offset, msg.partition, preview,
-                )
-                await consumer.commit()
+        while not shutdown_event.is_set():
+            # Poll with a bounded timeout so SIGTERM during idle periods
+            # exits the loop within ~1s.
+            records = await consumer.getmany(timeout_ms=1000, max_records=1)
+            if not records:
                 continue
 
-            job_id = event.get("job_id", "<unknown>")
-            logger.info(f"Job {job_id}: received")
-
-            # Pause consumer — process one job at a time
-            consumer.pause(*consumer.assignment())
-
-            reply: dict = {"job_id": job_id}
-            try:
-                result = await process_job(event)
-                reply["status"] = "ok"
-                reply["result"] = result
-            except Exception as exc:
-                logger.exception(f"Job {job_id}: failed")
-                reply["status"] = "error"
-                reply["error"] = str(exc)
-
-            # Publish reply before committing offset
-            await producer.send_and_wait(
-                config.kafka.reply_topic,
-                key=job_id.encode(),
-                value=serialize_result(reply).encode(),
-            )
-            logger.info(
-                f"Job {job_id}: reply published to {config.kafka.reply_topic}")
-
-            s3_key = event.get("s3_key")
-            if config.s3.delete_after_download and s3_key:
+            messages = [m for msgs in records.values() for m in msgs]
+            for msg in messages:
                 try:
-                    await s3_client.delete_audio(s3_key)
+                    event = json.loads(msg.value)
                 except Exception:
-                    logger.warning(
-                        f"Job {job_id}: failed to delete S3 object {s3_key!r}")
+                    preview = msg.value[:200] if msg.value else b""
+                    logger.error(
+                        "Failed to parse Kafka message (offset=%s, partition=%s), skipping. "
+                        "Raw value preview: %r",
+                        msg.offset, msg.partition, preview,
+                    )
+                    await consumer.commit()
+                    continue
 
-            await consumer.commit()
+                job_id = event.get("job_id", "<unknown>")
+                logger.info(f"Job {job_id}: received")
 
-            consumer.resume(*consumer.assignment())
-            logger.info(f"Job {job_id}: done, consumer resumed")
+                # Pause consumer — process one job at a time. `job_in_flight` is set
+                # before pause so the rebalance listener re-applies it if assignments
+                # change while this job runs.
+                job_in_flight[0] = True
+                consumer.pause(*consumer.assignment())
+
+                try:
+                    reply: dict = {"job_id": job_id}
+                    try:
+                        result = await process_job(event)
+                        reply["status"] = "ok"
+                        reply["result"] = result
+                    except Exception as exc:
+                        logger.exception(f"Job {job_id}: failed")
+                        reply["status"] = "error"
+                        reply["error"] = str(exc)
+                        # Pass exception type so the API can rehydrate typed
+                        # exceptions (e.g. InvalidAudioError → HTTP 422) instead
+                        # of collapsing every worker failure to RuntimeError/500.
+                        reply["error_type"] = type(exc).__name__
+
+                    # Publish reply before committing offset
+                    await producer.send_and_wait(
+                        config.kafka.reply_topic,
+                        key=job_id.encode(),
+                        value=serialize_result(reply).encode(),
+                    )
+                    logger.info(
+                        f"Job {job_id}: reply published to {config.kafka.reply_topic}")
+
+                    s3_key = event.get("s3_key")
+                    if config.s3.delete_after_download and s3_key:
+                        try:
+                            await s3_client.delete_audio(s3_key)
+                        except Exception:
+                            logger.warning(
+                                f"Job {job_id}: failed to delete S3 object {s3_key!r}")
+
+                    await consumer.commit()
+                finally:
+                    job_in_flight[0] = False
+                    consumer.resume(*consumer.assignment())
+                    logger.info(f"Job {job_id}: done, consumer resumed")
+
+        logger.info("Worker shutdown requested, exiting message loop")
 
     finally:
+        if sigterm_registered:
+            with contextlib.suppress(NotImplementedError, RuntimeError):
+                asyncio.get_running_loop().remove_signal_handler(signal.SIGTERM)
         if gpu_task is not None:
             gpu_task.cancel()
             with contextlib.suppress(asyncio.CancelledError, Exception):

--- a/src/whisperx_worker/processor.py
+++ b/src/whisperx_worker/processor.py
@@ -1,8 +1,6 @@
 import asyncio
 import json
 import logging
-import os
-import tempfile
 import time
 from typing import Any
 
@@ -18,7 +16,7 @@ from whisperx_api_server.backends.registry import (
 from whisperx_api_server.config import Language
 from whisperx_api_server.dependencies import get_config
 from whisperx_api_server.transcriber import (
-    _load_audio,
+    load_audio_from_bytes,
     _finalize_text,
     _cleanup_cache_only,
     _get_concurrency_semaphore,
@@ -54,7 +52,6 @@ async def process_job(event: dict[str, Any]) -> dict[str, Any]:
     diarize = params.get("diarize", False)
 
     start_time = time.perf_counter()
-    file_path = None
     audio = None
     concurrency_sem = _get_concurrency_semaphore()
     semaphore_acquired = False
@@ -69,21 +66,11 @@ async def process_job(event: dict[str, Any]) -> dict[str, Any]:
             f"Job {job_id}: S3 download took {profile['s3_download']:.2f} seconds")
 
         t0 = time.perf_counter()
-        suffix = f"_{filename}"
-        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
-            await asyncio.to_thread(tmp.write, audio_bytes)
-            file_path = tmp.name
-        del audio_bytes
-        profile["file_write"] = time.perf_counter() - t0
-
-        t0 = time.perf_counter()
-        audio = await _load_audio(file_path, job_id)
+        audio = await load_audio_from_bytes(audio_bytes, job_id)
         profile["audio_load"] = time.perf_counter() - t0
+        del audio_bytes
         logger.info(
             f"Job {job_id}: loading audio took {profile['audio_load']:.2f} seconds")
-
-        os.remove(file_path)
-        file_path = None
 
         if concurrency_sem:
             await concurrency_sem.acquire()
@@ -168,8 +155,6 @@ async def process_job(event: dict[str, Any]) -> dict[str, Any]:
     finally:
         if concurrency_sem and semaphore_acquired:
             concurrency_sem.release()
-        if file_path and os.path.exists(file_path):
-            os.remove(file_path)
         if config.audio_cleanup and audio is not None:
             del audio
             logger.info(f"Job {job_id}: audio data cleaned up")

--- a/src/whisperx_worker/processor.py
+++ b/src/whisperx_worker/processor.py
@@ -54,7 +54,6 @@ async def process_job(event: dict[str, Any]) -> dict[str, Any]:
     start_time = time.perf_counter()
     audio = None
     concurrency_sem = _get_concurrency_semaphore()
-    semaphore_acquired = False
     profile: dict[str, float] = {}
 
     try:
@@ -74,87 +73,88 @@ async def process_job(event: dict[str, Any]) -> dict[str, Any]:
 
         if concurrency_sem:
             await concurrency_sem.acquire()
-            semaphore_acquired = True
             logger.debug(f"Job {job_id}: acquired GPU concurrency semaphore")
 
-        selected_backends = resolve_stage_backends()
-        transcription_backend = get_transcription_backend(
-            selected_backends.transcription)
-        alignment_backend = get_alignment_backend(
-            selected_backends.alignment) if (align or diarize) else None
-        diarization_backend = get_diarization_backend(
-            selected_backends.diarization) if diarize else None
+        try:
+            selected_backends = resolve_stage_backends()
+            transcription_backend = get_transcription_backend(
+                selected_backends.transcription)
+            alignment_backend = get_alignment_backend(
+                selected_backends.alignment) if (align or diarize) else None
+            diarization_backend = get_diarization_backend(
+                selected_backends.diarization) if diarize else None
 
-        model_name = params.get(
-            "model_name") or get_default_transcription_model_name()
-        raw_language = params.get("language")
-        language = Language(
-            raw_language) if raw_language else config.default_language
-        asr_options = params.get("asr_options")
-        task = params.get("task", "transcribe")
+            model_name = params.get(
+                "model_name") or get_default_transcription_model_name()
+            raw_language = params.get("language")
+            language = Language(
+                raw_language) if raw_language else config.default_language
+            asr_options = params.get("asr_options")
+            task = params.get("task", "transcribe")
 
-        logger.info(
-            f"Job {job_id}: transcribing {filename} with model: {model_name}, "
-            f"options: {asr_options}, language: {language}, task: {task}, "
-            f"stage_backends: {selected_backends}"
-        )
-
-        t0 = time.perf_counter()
-        result = await transcription_backend.transcribe(
-            model_name=model_name,
-            audio=audio,
-            batch_size=params.get("batch_size", config.whisper.batch_size),
-            chunk_size=params.get("chunk_size", config.whisper.chunk_size),
-            language=language,
-            task=task,
-            asr_options=asr_options,
-            request_id=job_id,
-        )
-        profile["transcribe"] = time.perf_counter() - t0
-        logger.info(
-            f"Job {job_id}: transcription took {profile['transcribe']:.2f} seconds")
-
-        if align or diarize:
-            if alignment_backend is None:
-                raise RuntimeError(
-                    "Alignment backend is not initialized but alignment or diarization was requested"
-                )
-            t0 = time.perf_counter()
-            result = await alignment_backend.align(
-                result=result, audio=audio, request_id=job_id
+            logger.info(
+                f"Job {job_id}: transcribing {filename} with model: {model_name}, "
+                f"options: {asr_options}, language: {language}, task: {task}, "
+                f"stage_backends: {selected_backends}"
             )
-            profile["align"] = time.perf_counter() - t0
-            logger.debug(
-                f"Job {job_id}: alignment took {profile['align']:.2f} seconds")
 
-        if diarize:
             t0 = time.perf_counter()
-            result = await diarization_backend.diarize(
-                result=result,
+            result = await transcription_backend.transcribe(
+                model_name=model_name,
                 audio=audio,
-                speaker_embeddings=params.get("speaker_embeddings", False),
+                batch_size=params.get("batch_size", config.whisper.batch_size),
+                chunk_size=params.get("chunk_size", config.whisper.chunk_size),
+                language=language,
+                task=task,
+                asr_options=asr_options,
                 request_id=job_id,
             )
-            profile["diarize"] = time.perf_counter() - t0
+            profile["transcribe"] = time.perf_counter() - t0
+            logger.info(
+                f"Job {job_id}: transcription took {profile['transcribe']:.2f} seconds")
+
+            if align or diarize:
+                if alignment_backend is None:
+                    raise RuntimeError(
+                        "Alignment backend is not initialized but alignment or diarization was requested"
+                    )
+                t0 = time.perf_counter()
+                result = await alignment_backend.align(
+                    result=result, audio=audio, request_id=job_id
+                )
+                profile["align"] = time.perf_counter() - t0
+                logger.debug(
+                    f"Job {job_id}: alignment took {profile['align']:.2f} seconds")
+
+            if diarize:
+                t0 = time.perf_counter()
+                result = await diarization_backend.diarize(
+                    result=result,
+                    audio=audio,
+                    speaker_embeddings=params.get("speaker_embeddings", False),
+                    request_id=job_id,
+                )
+                profile["diarize"] = time.perf_counter() - t0
+                logger.debug(
+                    f"Job {job_id}: diarization took {profile['diarize']:.2f} seconds")
+
+            t0 = time.perf_counter()
+            result = _finalize_text(result, align or diarize)
+            profile["finalize"] = time.perf_counter() - t0
+
+            total = time.perf_counter() - start_time
+            logger.info(f"Job {job_id}: transcription complete for {filename}")
             logger.debug(
-                f"Job {job_id}: diarization took {profile['diarize']:.2f} seconds")
-
-        t0 = time.perf_counter()
-        result = _finalize_text(result, align or diarize)
-        profile["finalize"] = time.perf_counter() - t0
-
-        total = time.perf_counter() - start_time
-        logger.info(f"Job {job_id}: transcription complete for {filename}")
-        logger.debug(
-            f"Job {job_id}: profile: total={total:.2f}s | "
-            + " | ".join(f"{k}={v:.2f}s" for k, v in profile.items())
-            + f" | (other={total - sum(profile.values()):.2f}s)"
-        )
-        return result
+                f"Job {job_id}: profile: total={total:.2f}s | "
+                + " | ".join(f"{k}={v:.2f}s" for k, v in profile.items())
+                + f" | (other={total - sum(profile.values()):.2f}s)"
+            )
+            return result
+        finally:
+            if concurrency_sem:
+                concurrency_sem.release()
 
     finally:
-        if concurrency_sem and semaphore_acquired:
-            concurrency_sem.release()
         if config.audio_cleanup and audio is not None:
             del audio
             logger.info(f"Job {job_id}: audio data cleaned up")


### PR DESCRIPTION
Audio decode (37ca23e): async ffmpeg subprocess, decode-to-f32le straight through an in-memory pipe, separate decode admission semaphore so decode of request N+1 overlaps with inference of request N. Model/IO thread pools split into a dedicated executors.py module.

Hardening (43d83d2):
- Typed errors → correct HTTP codes: ffmpeg failure → 422, oversize → 413, CUDA OOM → 503, timeout → 504 (was all 500). Exception type tunneled across the Kafka reply boundary so worker-side InvalidAudioError still surfaces as 422.
- /models/unload race fixed: pop cache + lock atomically, hold lock for the whole teardown, offload model.to("cpu") + empty_cache() to the IO executor. Same pattern for align + diarize. Endpoints became async.
- Filename sanitization in one place (_safe_filename) — covers both the tempfile suffix (direct mode) and the S3 key (Kafka mode).
- realtime_factor guarded against zero-length audio; X-Request-ID validated; orphan alignment_locks entries dropped on whitelist evict; writer-join timeout 30s → 10s; added max_upload_size_bytes config (0 = unlimited).
- whisperx_http_errors_total{error_type} taxonomy extended for 4xx.
- Kafka mode: disable /models/*, /align_models/*, /diarize_models/* — the API owns no model state there, they were lying about cache contents or 500-ing on missing volume mounts. Clean 404s now. Direct mode unchanged.