### PR TITLE
Enhance API and Web UI with new features and observability

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,3 +11,6 @@ whisperx/torch-home
 whisperx/test-files
 Dockerfile*
 .scannerwork
+.venv
+webui/node_modules
+webui/dist

--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,14 @@ MINIO_ROOT_PASSWORD=minioadmin
 # S3__REGION=us-east-1
 # S3__OBJECT_EXPIRY_DAYS=1          # Days before uploaded audio is auto-deleted
 
+# ── Web UI (optional) ───────────────────────────────────────────────────────────
+# Serve the bundled browser UI at /webui. Requires assets built into the image
+# (docker compose build with BUILD_WEBUI=build in the environment / this file) or a
+# local `cd webui && bun install --frozen-lockfile && bun run build`.
+# WEBUI__ENABLED=true
+# BUILD_WEBUI=build                 # compose build arg: build the UI into the image
+# WEBUI__DIST_DIR=/path/to/webui/dist  # only for non-standard asset locations
+
 # ── Logging ─────────────────────────────────────────────────────────────────────
 # LOG_LEVEL=INFO                    # DEBUG | INFO | WARNING | ERROR | CRITICAL
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,18 @@ jobs:
           rc=$?
           [ "$rc" = "5" ] && exit 0
           exit $rc
+
+  webui:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: webui
+    steps:
+      - uses: actions/checkout@v5
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.x"
+      - run: bun install --frozen-lockfile
+      - run: bun run lint
+      - run: bun run build
+      - run: bun run test

--- a/.github/workflows/deploy-images.yml
+++ b/.github/workflows/deploy-images.yml
@@ -17,27 +17,37 @@ jobs:
           - target: cpu
             file: ./Dockerfile.cpu
             image: whisperx-api-server
-            build_args: ""
+            build_args: |
+              BUILD_WEBUI=build
+              UV_EXTRA_ARGS=--extra metrics
           - target: cuda
             file: ./Dockerfile.cuda
             image: whisperx-api-server
-            build_args: ""
+            build_args: |
+              BUILD_WEBUI=build
+              UV_EXTRA_ARGS=--extra metrics
           - target: cpu-kafka
             file: ./Dockerfile.cpu
             image: whisperx-api-server
-            build_args: "UV_EXTRA_ARGS=--extra kafka"
+            build_args: |
+              BUILD_WEBUI=build
+              UV_EXTRA_ARGS=--extra kafka --extra metrics
           - target: cuda-kafka
             file: ./Dockerfile.cuda
             image: whisperx-api-server
-            build_args: "UV_EXTRA_ARGS=--extra kafka"
+            build_args: |
+              BUILD_WEBUI=build
+              UV_EXTRA_ARGS=--extra kafka --extra metrics
           - target: worker-cpu
             file: ./Dockerfile.worker-cpu
             image: whisperx-worker
-            build_args: ""
+            build_args: |
+              UV_EXTRA_ARGS=--extra metrics
           - target: worker-cuda
             file: ./Dockerfile.worker-cuda
             image: whisperx-worker
-            build_args: ""
+            build_args: |
+              UV_EXTRA_ARGS=--extra metrics
 
     steps:
     - name: Checkout code

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,4 +1,21 @@
 ARG BASE_IMAGE=ubuntu:24.04
+# Optional web UI: BUILD_WEBUI=build compiles webui/ in a bun stage; the default
+# (skip) never pulls bun and ships an empty webui/dist. Named distinctly from the
+# runtime WEBUI__* config so this build arg can't collide with the `webui` config field.
+ARG BUILD_WEBUI=skip
+
+FROM oven/bun:1.3-alpine AS webui-build
+WORKDIR /webui
+COPY webui/package.json webui/bun.lock ./
+RUN bun install --frozen-lockfile
+COPY webui/ ./
+RUN bun run build
+
+FROM ${BASE_IMAGE} AS webui-skip
+RUN mkdir -p /webui/dist
+
+FROM webui-${BUILD_WEBUI} AS webui
+
 FROM ${BASE_IMAGE}
 
 LABEL org.opencontainers.image.source="https://github.com/nyralei/whisperx-api-server"
@@ -31,6 +48,9 @@ COPY --chown=ubuntu src/whisperx_api_server ./src/whisperx_api_server
 RUN uv pip install --no-deps .
 # Fails the build if the wheel was built empty (src-layout packaging regression).
 RUN python -c "import whisperx_api_server.main"
+
+# Empty unless built with --build-arg BUILD_WEBUI=build; served only when WEBUI__ENABLED=true.
+COPY --chown=ubuntu --from=webui /webui/dist ./webui/dist
 
 RUN mkdir -p $HOME/.cache/huggingface && mkdir -p $HOME/.cache/torch
 ENV UVICORN_HOST=0.0.0.0

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -1,6 +1,23 @@
 ARG UBUNTU_VERSION=24.04
 ARG CUDA_VERSION=12.8.1
 ARG BASE_IMAGE=nvidia/cuda:${CUDA_VERSION}-cudnn-runtime-ubuntu${UBUNTU_VERSION}
+# Optional web UI: BUILD_WEBUI=build compiles webui/ in a bun stage; the default
+# (skip) never pulls bun and ships an empty webui/dist. Named distinctly from the
+# runtime WEBUI__* config so this build arg can't collide with the `webui` config field.
+ARG BUILD_WEBUI=skip
+
+FROM oven/bun:1.3-alpine AS webui-build
+WORKDIR /webui
+COPY webui/package.json webui/bun.lock ./
+RUN bun install --frozen-lockfile
+COPY webui/ ./
+RUN bun run build
+
+FROM ${BASE_IMAGE} AS webui-skip
+RUN mkdir -p /webui/dist
+
+FROM webui-${BUILD_WEBUI} AS webui
+
 FROM ${BASE_IMAGE}
 
 LABEL org.opencontainers.image.source="https://github.com/nyralei/whisperx-api-server"
@@ -35,6 +52,9 @@ COPY --chown=ubuntu src/whisperx_api_server ./src/whisperx_api_server
 RUN uv pip install --no-deps .
 # Fails the build if the wheel was built empty (src-layout packaging regression).
 RUN python -c "import whisperx_api_server.main"
+
+# Empty unless built with --build-arg BUILD_WEBUI=build; served only when WEBUI__ENABLED=true.
+COPY --chown=ubuntu --from=webui /webui/dist ./webui/dist
 COPY --chown=ubuntu cuda-docker-entrypoint.sh ./docker-entrypoint.sh
 RUN chmod +x ./docker-entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A FastAPI server that exposes [WhisperX](https://github.com/m-bain/WhisperX) as 
 - **Live request status** — poll an in-flight transcription's current pipeline stage by request id, in both direct and Kafka modes
 - **Pluggable backends** — swap transcription, alignment, and diarization implementations per stage
 - **API key auth** — single key or a JSON key-map for multi-client setups
+- **Optional web UI** — a built-in browser client (upload, live stage progress, interactive transcript, exports), off by default
 
 ## Quick Start
 
@@ -70,6 +71,32 @@ docker compose -f compose-kafka.yaml --profile cpu-observe up
 | 7 | CUDA + Kafka + Observability | `cuda-observe` | `compose-kafka.yaml` |
 | 8 | CPU + Kafka + Observability | `cpu-observe` | `compose-kafka.yaml` |
 
+## Web UI (optional)
+
+A single-page browser client for the API lives in [`webui/`](webui/) (React + Vite + TypeScript + Tailwind). It is a thin client over the public endpoints — it adds no API routes and no Python dependencies, and the core API behaves identically whether it is enabled or not (covered by a test). Features: drag-and-drop upload with progress, all transcription form parameters, a live pipeline-stage timeline (client-generated `X-Request-ID` + status polling, working in both direct and Kafka modes), an interactive transcript with click-to-seek, word-level highlighting and color-coded speakers, export buttons for every response format, one-click re-run of the same file with adjusted parameters (the file stays loaded in the browser — no re-selection), links to the interactive API docs (Swagger UI / ReDoc), and a light/dark theme toggle (follows the OS by default).
+
+**Enable it** with `WEBUI__ENABLED=true`. The UI is then served at `/webui/` (with `/` redirecting to it); when the flag is off — the default — neither route exists. The server fails fast at startup if the flag is on but no build output is found.
+
+**Docker images** build the UI via an opt-in build arg (default `skip` — no bun stage runs, existing profiles build exactly as before):
+
+```bash
+# Standalone; same BUILD_WEBUI=build works for compose-kafka.yaml
+BUILD_WEBUI=build docker compose --profile cuda build
+# then run with WEBUI__ENABLED=true in .env
+docker compose --profile cuda up
+```
+
+**Without Docker**, build the assets once (Bun ≥ 1.3; no Bun process is needed at runtime):
+
+```bash
+cd webui && bun install --frozen-lockfile && bun run build
+WEBUI__ENABLED=true whisperx-api
+```
+
+The server looks for `webui/dist` relative to the working directory, then the repo root; point `WEBUI__DIST_DIR` at the build output for non-standard layouts. For UI development, `bun run dev` starts Vite on `:5173` and proxies API calls to `http://localhost:8000` (override with `WEBUI_DEV_API`). The frontend carries its own quality gates — `bun run lint` (Biome) and `bun run test` (Vitest) — which run in CI on every push.
+
+**Auth:** the static assets themselves are served without an API key (they contain nothing sensitive); every API call the UI makes carries the key the user enters. The UI probes `GET /info` on load — a 200 without credentials means no key is configured and the key field is hidden.
+
 ## Configuration
 
 All settings are environment variables. Nested fields use `__` as a delimiter (e.g. `WHISPER__MODEL=large-v3`).
@@ -87,6 +114,7 @@ All available settings are defined in [`config.py`](src/whisperx_api_server/conf
 | `AUTH_REQUIRED` | `false` | When `true`, refuse to start unless `API_KEY` or `API_KEYS_FILE` is set |
 | `MODE` | `direct` | `direct` or `kafka` |
 | `MAX_CONCURRENT_TRANSCRIPTIONS` | `1` | Max concurrent ML inferences (transcribe / align / diarize). `0` = unlimited. See the concurrency note below. |
+| `WEBUI__ENABLED` | `false` | Serve the bundled [web UI](#web-ui-optional) at `/webui` |
 
 > **`MAX_CONCURRENT_TRANSCRIPTIONS` parallelizes across *distinct* models, not within one.** Each transcription pipeline holds a per-model lock during the transcribe step, so two requests for the **same** model still run one at a time even with the limit raised — the setting lets a request for a *different* model (and the align / diarize stages) proceed concurrently. To raise same-model throughput, add GPUs or run more replicas / workers. Whichever process runs inference (the API in direct mode, the worker in Kafka mode) logs this caveat at startup when the limit is >1.
 
@@ -131,6 +159,8 @@ Transcribe an audio file. Compatible with the [OpenAI transcription API](https:/
 | `align` | bool | `true` | Enable word-level alignment (required for subtitle formats) |
 | `diarize` | bool | `false` | Enable speaker diarization (requires `align=true`) |
 | `speaker_embeddings` | bool | `false` | Include speaker embeddings in diarization output |
+| `min_speakers` | int | — | Lower bound on the speaker count for diarization (≥ 1) |
+| `max_speakers` | int | — | Upper bound on the speaker count for diarization (≥ `min_speakers`) |
 | `highlight_words` | bool | `false` | Highlight words in `vtt`/`srt` output |
 | `suppress_numerals` | bool | `true` | Spell out numbers |
 | `hotwords` | string | — | Comma-separated hotwords to bias toward |
@@ -219,6 +249,20 @@ Terminal states (`completed` / `failed`) are retained for `REQUEST_STATUS__TTL_S
 
 ---
 
+### `GET /v1/audio/transcriptions/{request_id}/events`
+
+Streams the processing status of a transcription request as Server-Sent Events. Each state change is emitted as a `data:` line carrying the status JSON — `status` (`queued` / `in_progress` / `completed` / `failed`), the active `stage`, the per-stage `stages[]` timeline, and `error` / `error_type` on failure. `: ping` comment lines are sent while idle to hold the connection open. The stream ends when the request reaches a terminal state, the client disconnects, or `REQUEST_STATUS__SSE_MAX_DURATION_SECONDS` elapses.
+
+The client sets a known `X-Request-ID` (matching `[A-Za-z0-9._-]{1,128}`) on the transcription POST and opens the stream alongside it:
+
+```bash
+curl -N http://localhost:8000/v1/audio/transcriptions/my-request-1/events
+```
+
+When auth is configured the endpoint requires the API key like every other route, so consume it with a header-capable client rather than a browser `EventSource`. A malformed id returns `400 Bad Request`; an unknown, expired, or not-yet-tracked id returns `404 Not Found`.
+
+---
+
 ### Async job submission (Kafka mode)
 
 By default the transcription POST is synchronous — the HTTP response arrives only when the whole pipeline finishes. In **Kafka mode** you can instead submit the job and return immediately by setting the `async` form field, then fetch the result later. This decouples slow transcriptions from the request connection (no client read-timeout to tune) and survives an API-replica restart, because the result is read from durable storage rather than an in-memory future.
@@ -248,7 +292,7 @@ Poll `status_url` (see above) to follow progress, then fetch `result_url` once `
 
 ### `GET /v1/audio/transcriptions/{request_id}/result`
 
-Fetch the final result of an async job (Kafka mode only). It reads the stored `results/{job_id}` envelope from S3, so it works from any replica and after restarts, with no in-memory state required.
+Fetch and (re-)format the final result of a finished transcription without re-running the pipeline. In **Kafka mode** it reads the stored `results/{job_id}` envelope from S3, so it works from any replica and after restarts. In **direct mode** it reads an on-disk result store written when the synchronous POST completes — enabled by default (`RESULT_STORE__ENABLED`), bounded by count and age, and best-effort (a temp dir, not shared across replicas or guaranteed across restarts).
 
 **Query parameters**
 
@@ -263,10 +307,10 @@ Formatting is applied at fetch time from these query parameters — the `respons
 
 - `200 OK` — formatted transcription (Content-Type per `response_format`), identical to what the synchronous POST would have returned
 - `400 Bad Request` — malformed `request_id`
-- `404 Not Found` — result not available (still pending, unknown, or expired); also returned in direct mode
+- `404 Not Found` — result not available (still pending, unknown, expired, or — in direct mode — never stored / result store disabled)
 - worker failures are replayed with the same status code the synchronous endpoint returns (e.g. invalid audio → `422`, timeout → `504`), not `404`
 
-Results are retained for `S3__OBJECT_EXPIRY_DAYS` (default 1 day) via the bucket lifecycle policy; after that the id 404s.
+Kafka-mode results are retained for `S3__OBJECT_EXPIRY_DAYS` (default 1 day) via the bucket lifecycle policy; direct-mode results for `RESULT_STORE__TTL_SECONDS` (default 1h), up to `RESULT_STORE__MAX_ENTRIES` files. After that the id 404s.
 
 ---
 
@@ -296,7 +340,7 @@ Format the `result` yourself, or ignore the body and fetch `result_url` for a fo
 
 ### `GET /info`
 
-Returns the running version, mode, uptime, concurrency / queue state, and (in Kafka mode) discovered worker membership. Add `?detail=full` for extended Kafka topology.
+Returns the running version, mode, uptime, concurrency / queue state, and (in Kafka mode) discovered worker membership. Also reports `max_upload_size_bytes` (`null` = unlimited) and `subtitle_formats_available` (whether this process can render `vtt`/`srt`/`aud`/`vtt_json`), so a client can pre-validate uploads and format support. Add `?detail=full` for extended Kafka topology.
 
 ---
 
@@ -310,6 +354,7 @@ Returns `{"status": "healthy"}`. Not protected by API key auth.
 
 | Endpoint | Description |
 |---|---|
+| `GET /models/catalog` | List known transcription model names + configured default (both modes) |
 | `GET /models/list` | List loaded transcription models |
 | `POST /models/load` | Load a model (`model` param) |
 | `POST /models/unload` | Unload a model (`model` param) |

--- a/compose-kafka.yaml
+++ b/compose-kafka.yaml
@@ -17,6 +17,7 @@ x-api-base: &api-base
     dockerfile: Dockerfile.cpu
     args:
       UV_EXTRA_ARGS: "--extra kafka"
+      BUILD_WEBUI: ${BUILD_WEBUI:-skip}
   env_file:
     - .env
   depends_on:
@@ -178,6 +179,7 @@ services:
       dockerfile: Dockerfile.cpu
       args:
         UV_EXTRA_ARGS: "--extra kafka --extra metrics"
+        BUILD_WEBUI: ${BUILD_WEBUI:-skip}
     environment:
       <<: *api-env
       METRICS_ENABLED: "true"

--- a/compose.yaml
+++ b/compose.yaml
@@ -13,6 +13,8 @@ x-api-cuda-base: &api-cuda-base
   build:
     context: .
     dockerfile: Dockerfile.cuda
+    args:
+      BUILD_WEBUI: ${BUILD_WEBUI:-skip}
   env_file:
     - .env
   healthcheck:
@@ -39,6 +41,8 @@ x-api-cpu-base: &api-cpu-base
   build:
     context: .
     dockerfile: Dockerfile.cpu
+    args:
+      BUILD_WEBUI: ${BUILD_WEBUI:-skip}
   env_file:
     - .env
   healthcheck:
@@ -88,6 +92,7 @@ services:
       dockerfile: Dockerfile.cuda
       args:
         UV_EXTRA_ARGS: "--extra metrics"
+        BUILD_WEBUI: ${BUILD_WEBUI:-skip}
     environment:
       METRICS_ENABLED: "true"
 
@@ -100,6 +105,7 @@ services:
       dockerfile: Dockerfile.cpu
       args:
         UV_EXTRA_ARGS: "--extra metrics"
+        BUILD_WEBUI: ${BUILD_WEBUI:-skip}
     environment:
       METRICS_ENABLED: "true"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "whisperx-api-server"
-version = "1.3.0.4"
+version = "1.3.1.0"
 description = "FastAPI server for WhisperX transcription with OpenAI-like API"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"

--- a/src/whisperx_api_server/backends/contracts.py
+++ b/src/whisperx_api_server/backends/contracts.py
@@ -76,4 +76,6 @@ class DiarizationBackend(Protocol):
         audio: np.ndarray,
         speaker_embeddings: bool,
         request_id: str,
+        min_speakers: int | None = None,
+        max_speakers: int | None = None,
     ) -> dict[str, Any]: ...

--- a/src/whisperx_api_server/backends/whisperx_backend.py
+++ b/src/whisperx_api_server/backends/whisperx_backend.py
@@ -324,6 +324,8 @@ class WhisperXDiarizationBackend:
         audio: np.ndarray,
         speaker_embeddings: bool,
         request_id: str,
+        min_speakers: int | None = None,
+        max_speakers: int | None = None,
     ) -> dict[str, Any]:
         if "segments" not in result:
             raise ValueError(
@@ -345,11 +347,19 @@ class WhisperXDiarizationBackend:
             time.perf_counter() - diarization_model_start,
         )
 
+        speaker_bounds: dict[str, int] = {}
+        if min_speakers is not None:
+            speaker_bounds["min_speakers"] = min_speakers
+        if max_speakers is not None:
+            speaker_bounds["max_speakers"] = max_speakers
+
         def _run_diarization() -> tuple[Any, Any]:
             with torch.inference_mode():
                 if speaker_embeddings:
-                    return diarize_model(audio=audio, return_embeddings=True)
-                return diarize_model(audio=audio), None
+                    return diarize_model(
+                        audio=audio, return_embeddings=True, **speaker_bounds
+                    )
+                return diarize_model(audio=audio, **speaker_bounds), None
 
         # Refcount so concurrent /diarize_models/unload sees this is in use.
         acquire_diarize_pipeline(config.diarization.model)

--- a/src/whisperx_api_server/config.py
+++ b/src/whisperx_api_server/config.py
@@ -303,6 +303,15 @@ class MetricsConfig(BaseModel):
     worker_port: int = Field(default=9091)
 
 
+class WebUIConfig(BaseModel):
+    # When false (default), neither the /webui static mount nor the "/" redirect
+    # is registered — the HTTP surface is identical to a UI-less deployment.
+    enabled: bool = Field(default=False)
+    # Directory containing the built UI (index.html + assets/). Unset = auto-detect:
+    # ./webui/dist relative to the working directory, then the source checkout.
+    dist_dir: str | None = Field(default=None)
+
+
 class RequestStatusConfig(BaseModel):
     # How long completed/failed states are retained for polling after the
     # request finishes. Set to 0 to drop terminal states immediately (only
@@ -313,6 +322,21 @@ class RequestStatusConfig(BaseModel):
     max_entries: int = Field(default=4096, gt=0)
     # Interval for the background eviction sweep.
     cleanup_interval_seconds: float = Field(default=30.0, gt=0.0)
+    # SSE stream (.../events): internal poll cadence, heartbeat, and max lifetime.
+    sse_poll_interval_seconds: float = Field(default=0.5, gt=0.0)
+    sse_heartbeat_seconds: float = Field(default=15.0, gt=0.0)
+    sse_max_duration_seconds: float = Field(default=3600.0, gt=0.0)
+
+
+class ResultStoreConfig(BaseModel):
+    # Direct mode only: persist finished verbose results to disk so GET .../result
+    # can re-format them without re-running the pipeline. Kafka mode uses S3.
+    enabled: bool = Field(default=True)
+    # Unset = <tempdir>/whisperx-results.
+    dir: str | None = Field(default=None)
+    # 0 = no time-based expiry (bounded by max_entries only).
+    ttl_seconds: float = Field(default=3600.0, ge=0.0)
+    max_entries: int = Field(default=64, gt=0)
 
 
 class Config(BaseSettings):
@@ -353,6 +377,8 @@ class Config(BaseSettings):
     diarization: DiarizeConfig = DiarizeConfig()
 
     backends: BackendsConfig = BackendsConfig()
+
+    result_store: ResultStoreConfig = ResultStoreConfig()
 
     cache_cleanup: bool = True
 
@@ -408,6 +434,8 @@ class Config(BaseSettings):
     metrics: MetricsConfig = MetricsConfig()
 
     request_status: RequestStatusConfig = RequestStatusConfig()
+
+    webui: WebUIConfig = WebUIConfig()
 
     @model_validator(mode="before")
     @classmethod

--- a/src/whisperx_api_server/formatters.py
+++ b/src/whisperx_api_server/formatters.py
@@ -32,6 +32,15 @@ def update_options(kwargs, defaults):
     return options
 
 
+def subtitle_formats_supported() -> bool:
+    """True if this process can render srt/vtt/aud/vtt_json (whisperx importable)."""
+    try:
+        from whisperx.utils import WriteAudacity, WriteSRT, WriteVTT  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
 def _get_whisperx_writer(writer_format: ResponseFormat):
     try:
         from whisperx.utils import WriteAudacity, WriteSRT, WriteVTT

--- a/src/whisperx_api_server/main.py
+++ b/src/whisperx_api_server/main.py
@@ -23,6 +23,9 @@ from whisperx_api_server.config import DistributedMode
 from whisperx_api_server.dependencies import ApiKeyDependency, get_config
 from whisperx_api_server.logger import setup_logger
 from whisperx_api_server.routers.models import (
+    catalog_router as models_catalog_router,
+)
+from whisperx_api_server.routers.models import (
     router as models_router,
 )
 from whisperx_api_server.routers.observability import (
@@ -400,8 +403,15 @@ def create_app() -> FastAPI:
             "Kafka mode: /models/*, /align_models/*, /diarize_models/* endpoints "
             "are disabled (model lifecycle lives in worker processes)"
         )
+    # Static model catalog is available in both modes.
+    app.include_router(models_catalog_router, dependencies=dependencies)
     app.include_router(transcribe_router, dependencies=dependencies)
     app.include_router(status_router, dependencies=dependencies)
+
+    if config.webui.enabled:
+        from whisperx_api_server.webui import mount_webui
+
+        mount_webui(app, config)
 
     if config.allow_origins is not None:
         app.add_middleware(

--- a/src/whisperx_api_server/result_store.py
+++ b/src/whisperx_api_server/result_store.py
@@ -1,0 +1,147 @@
+"""On-disk store of finished direct-mode transcription results.
+
+Direct mode returns synchronously and has no durable S3 store like Kafka mode.
+Persisting the verbose result to a small JSON file lets GET .../result re-format a
+finished job (e.g. export srt/aud) without re-running the pipeline, while keeping
+resident memory flat. Bounded on disk by entry count and TTL; best-effort,
+single-replica, and not expected to survive a reboot.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import re
+import tempfile
+import threading
+import time
+from typing import Any
+
+from whisperx_api_server.dependencies import get_config
+
+logger = logging.getLogger(__name__)
+
+_SAFE_ID = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
+_lock = threading.Lock()
+
+
+def _json_default(obj: Any) -> Any:
+    item = getattr(obj, "item", None)
+    if callable(item):
+        with contextlib.suppress(Exception):
+            return obj.item()
+    tolist = getattr(obj, "tolist", None)
+    if callable(tolist):
+        return obj.tolist()
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
+
+
+def _resolve_dir(cfg: Any) -> str:
+    directory = cfg.dir or os.path.join(tempfile.gettempdir(), "whisperx-results")
+    os.makedirs(directory, exist_ok=True)
+    return directory
+
+
+def _enforce_capacity(directory: str, cap: int) -> None:
+    if cap <= 0:
+        return
+    with _lock:
+        try:
+            paths = [
+                os.path.join(directory, n)
+                for n in os.listdir(directory)
+                if n.endswith(".json")
+            ]
+        except OSError:
+            return
+        if len(paths) <= cap:
+            return
+        dated = []
+        for p in paths:
+            with contextlib.suppress(OSError):
+                dated.append((os.path.getmtime(p), p))
+        dated.sort()
+        for _, p in dated[: len(dated) - cap]:
+            with contextlib.suppress(OSError):
+                os.remove(p)
+
+
+def put(request_id: str, result: dict[str, Any]) -> None:
+    """Persist a finished result when the store is enabled. Best-effort; never raises."""
+    if not request_id or not _SAFE_ID.match(request_id):
+        return
+    cfg = get_config().result_store
+    if not cfg.enabled:
+        return
+    directory = _resolve_dir(cfg)
+    path = os.path.join(directory, f"{request_id}.json")
+    tmp = f"{path}.{os.getpid()}.tmp"
+    try:
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(result, f, default=_json_default)
+        os.replace(tmp, path)
+    except Exception:
+        logger.warning("result_store: failed to persist %s", request_id, exc_info=True)
+        with contextlib.suppress(OSError):
+            os.remove(tmp)
+        return
+    _enforce_capacity(directory, cfg.max_entries)
+
+
+def get(request_id: str) -> dict[str, Any] | None:
+    """Return the stored result, or None if absent/expired. TTL enforced on read."""
+    if not request_id or not _SAFE_ID.match(request_id):
+        return None
+    cfg = get_config().result_store
+    path = os.path.join(_resolve_dir(cfg), f"{request_id}.json")
+    try:
+        mtime = os.path.getmtime(path)
+    except OSError:
+        return None
+    if cfg.ttl_seconds > 0 and time.time() - mtime > cfg.ttl_seconds:
+        with contextlib.suppress(OSError):
+            os.remove(path)
+        return None
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        logger.warning("result_store: failed to read %s", request_id, exc_info=True)
+        return None
+
+
+def evict_expired(now: float | None = None) -> int:
+    """Delete result files older than ttl_seconds. Returns count removed."""
+    cfg = get_config().result_store
+    if cfg.ttl_seconds <= 0:
+        return 0
+    directory = _resolve_dir(cfg)
+    cutoff = (now if now is not None else time.time()) - cfg.ttl_seconds
+    removed = 0
+    with _lock:
+        try:
+            names = os.listdir(directory)
+        except OSError:
+            return 0
+        for n in names:
+            if not n.endswith(".json"):
+                continue
+            p = os.path.join(directory, n)
+            try:
+                if os.path.getmtime(p) <= cutoff:
+                    os.remove(p)
+                    removed += 1
+            except OSError:
+                continue
+    return removed
+
+
+def _reset_for_tests() -> None:
+    directory = _resolve_dir(get_config().result_store)
+    with contextlib.suppress(OSError):
+        for n in os.listdir(directory):
+            if n.endswith(".json"):
+                with contextlib.suppress(OSError):
+                    os.remove(os.path.join(directory, n))

--- a/src/whisperx_api_server/routers/models.py
+++ b/src/whisperx_api_server/routers/models.py
@@ -13,13 +13,81 @@ from whisperx_api_server.backends.registry import (
     resolve_stage_backends,
 )
 from whisperx_api_server.config import (
+    DistributedMode,
     Language,
     MediaType,
 )
+from whisperx_api_server.dependencies import get_config
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+catalog_router = APIRouter()
+
+# Fallback for a slim install without faster-whisper; the live list is preferred
+# via faster_whisper.available_models(). Mirrors faster-whisper 1.2.x.
+KNOWN_TRANSCRIPTION_MODELS = (
+    "tiny.en",
+    "tiny",
+    "base.en",
+    "base",
+    "small.en",
+    "small",
+    "medium.en",
+    "medium",
+    "large-v1",
+    "large-v2",
+    "large-v3",
+    "large",
+    "distil-large-v2",
+    "distil-medium.en",
+    "distil-small.en",
+    "distil-large-v3",
+    "distil-large-v3.5",
+    "large-v3-turbo",
+    "turbo",
+)
+
+
+def _known_models() -> list[str]:
+    try:
+        from faster_whisper import available_models
+
+        return list(available_models())
+    except Exception:
+        return list(KNOWN_TRANSCRIPTION_MODELS)
+
+
+@catalog_router.get(
+    "/models/catalog",
+    description=(
+        "Curated catalog of known transcription model names plus the configured "
+        "default. In direct mode `loaded` lists models currently in this process's "
+        "cache; in Kafka mode `loaded` is null (models live in worker processes). "
+        "Available in both modes, unlike /models/list."
+    ),
+    tags=["models", "transcribe"],
+)
+def models_catalog():
+    config = get_config()
+    loaded: list[str] | None = None
+    if config.mode != DistributedMode.KAFKA:
+        try:
+            selected_backends = resolve_stage_backends()
+            loaded = get_transcription_backend(
+                selected_backends.transcription
+            ).list_loaded_models()
+        except Exception:
+            logger.warning("models_catalog: loaded-model enumeration failed")
+            loaded = None
+    return JSONResponse(
+        content={
+            "models": _known_models(),
+            "default": config.whisper.model,
+            "loaded": loaded,
+        },
+        media_type=MediaType.APPLICATION_JSON,
+    )
 
 
 def handle_default_openai_model(model_name: str) -> str:

--- a/src/whisperx_api_server/routers/observability.py
+++ b/src/whisperx_api_server/routers/observability.py
@@ -58,10 +58,14 @@ async def info(
     request: Request, detail: Literal["summary", "full"] = Query(default="summary")
 ):
     config = get_config()
+    from whisperx_api_server.formatters import subtitle_formats_supported
+
     payload: dict = {
         "version": _app_version(),
         "mode": config.mode.value,
         "uptime_seconds": round(time.monotonic() - _STARTED_AT, 1),
+        "max_upload_size_bytes": config.max_upload_size_bytes or None,
+        "subtitle_formats_available": subtitle_formats_supported(),
     }
 
     if config.mode == DistributedMode.KAFKA:

--- a/src/whisperx_api_server/routers/status.py
+++ b/src/whisperx_api_server/routers/status.py
@@ -1,15 +1,22 @@
-"""Request status router: GET /v1/audio/transcriptions/{request_id}/status."""
+"""Request status router: GET /v1/audio/transcriptions/{request_id}/status
+and the SSE push variant /events."""
 
+import asyncio
+import json
 import logging
 import re
+import time
 
-from fastapi import APIRouter, HTTPException, status
-from fastapi.responses import JSONResponse
+from fastapi import APIRouter, HTTPException, Request, status
+from fastapi.responses import JSONResponse, StreamingResponse
 
 from whisperx_api_server import request_status
 from whisperx_api_server.config import MediaType
+from whisperx_api_server.dependencies import get_config
 
 logger = logging.getLogger(__name__)
+
+_TERMINAL = ("completed", "failed")
 
 # Mirror src/whisperx_api_server/main.py:_REQUEST_ID_SAFE so a malformed ID
 # can't poison the not-found log line with control chars.
@@ -40,3 +47,65 @@ async def get_transcription_status(request_id: str):
             detail="Request not tracked (unknown, expired, or never received).",
         )
     return JSONResponse(content=state, media_type=MediaType.APPLICATION_JSON)
+
+
+@router.get(
+    "/v1/audio/transcriptions/{request_id}/events",
+    description=(
+        "Server-Sent Events stream of processing status for a transcription "
+        "request — one `data:` event per state change, `: ping` heartbeats while "
+        "idle, and stream close on terminal state, client disconnect, or timeout. "
+        "Replaces client-side polling of /status. 404 if the request is not tracked."
+    ),
+    tags=["Transcription"],
+)
+async def stream_transcription_events(request_id: str, request: Request):
+    if not _REQUEST_ID_SAFE.match(request_id):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid request_id format.",
+        )
+    if request_status.get(request_id) is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Request not tracked (unknown, expired, or never received).",
+        )
+
+    cfg = get_config().request_status
+
+    async def event_stream():
+        last_payload: str | None = None
+        last_emit = time.monotonic()
+        deadline = last_emit + cfg.sse_max_duration_seconds
+        while True:
+            snap = request_status.get(request_id)
+            if snap is None:
+                yield "event: expired\ndata: {}\n\n"
+                return
+            payload = json.dumps(snap, sort_keys=True)
+            now = time.monotonic()
+            if payload != last_payload:
+                last_payload = payload
+                last_emit = now
+                yield f"data: {json.dumps(snap)}\n\n"
+            elif now - last_emit >= cfg.sse_heartbeat_seconds:
+                last_emit = now
+                yield ": ping\n\n"
+            if snap.get("status") in _TERMINAL:
+                return
+            if now >= deadline:
+                yield "event: timeout\ndata: {}\n\n"
+                return
+            if await request.is_disconnected():
+                return
+            await asyncio.sleep(cfg.sse_poll_interval_seconds)
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/src/whisperx_api_server/routers/transcriptions.py
+++ b/src/whisperx_api_server/routers/transcriptions.py
@@ -20,7 +20,7 @@ from fastapi.responses import JSONResponse, Response
 import whisperx_api_server.kafka_client as kafka_client
 import whisperx_api_server.s3_client as s3_client
 import whisperx_api_server.transcriber as transcriber
-from whisperx_api_server import request_status, webhook
+from whisperx_api_server import request_status, result_store, webhook
 from whisperx_api_server.config import (
     Config,
     DistributedMode,
@@ -194,6 +194,8 @@ async def transcribe_audio(
     align: Annotated[bool, Form()] = True,
     diarize: Annotated[bool, Form()] = False,
     speaker_embeddings: Annotated[bool, Form()] = False,
+    min_speakers: Annotated[int | None, Form()] = None,
+    max_speakers: Annotated[int | None, Form()] = None,
     chunk_size: Annotated[int | None, Form()] = None,
     batch_size: Annotated[int | None, Form()] = None,
     is_async: Annotated[bool, Form(alias="async")] = False,
@@ -296,6 +298,24 @@ async def transcribe_audio(
                 detail=detail,
             )
 
+    for name, value in (("min_speakers", min_speakers), ("max_speakers", max_speakers)):
+        if value is not None and value < 1:
+            detail = f"{name} must be >= 1."
+            request_status.mark_failed(request_id, detail, "HTTPException")
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=detail
+            )
+    if (
+        min_speakers is not None
+        and max_speakers is not None
+        and min_speakers > max_speakers
+    ):
+        detail = "min_speakers cannot exceed max_speakers."
+        request_status.mark_failed(request_id, detail, "HTTPException")
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=detail
+        )
+
     word_timestamps = "word" in timestamp_granularities
 
     asr_options = {
@@ -315,6 +335,8 @@ async def transcribe_audio(
                 "align": align,
                 "diarize": diarize,
                 "speaker_embeddings": speaker_embeddings,
+                "min_speakers": min_speakers,
+                "max_speakers": max_speakers,
                 "batch_size": batch_size,
                 "chunk_size": chunk_size,
                 "asr_options": asr_options,
@@ -355,6 +377,8 @@ async def transcribe_audio(
                 align=align,
                 diarize=diarize,
                 speaker_embeddings=speaker_embeddings,
+                min_speakers=min_speakers,
+                max_speakers=max_speakers,
                 chunk_size=chunk_size,
                 request_id=request_id,
             )
@@ -375,6 +399,9 @@ async def transcribe_audio(
         _schedule_completion_webhook(
             background_tasks, config, request_id, transcription, callback_url
         )
+
+    if config.mode != DistributedMode.KAFKA:
+        result_store.put(request_id, transcription)
 
     return format_transcription(
         transcription, response_format, highlight_words=highlight_words
@@ -514,10 +541,12 @@ async def translate_audio(
 @router.get(
     "/v1/audio/transcriptions/{request_id}/result",
     description=(
-        "Fetch the final result of an async transcription job from durable "
-        "storage (Kafka mode). 404 while pending/unknown/expired; the mapped "
-        "error response for a failed job; the formatted transcription on success. "
-        "Availability is bounded by S3__OBJECT_EXPIRY_DAYS."
+        "Fetch and (re-)format the final result of a finished transcription job. "
+        "Kafka mode reads the durable S3 envelope (availability bounded by "
+        "S3__OBJECT_EXPIRY_DAYS); direct mode reads the on-disk result store "
+        "(bounded by RESULT_STORE__TTL_SECONDS / MAX_ENTRIES, and returns 404 when "
+        "RESULT_STORE__ENABLED is false). 404 while pending/unknown/expired; the "
+        "mapped error response for a failed job; the formatted transcription on success."
     ),
     tags=["Transcription"],
 )
@@ -532,13 +561,19 @@ async def get_transcription_result(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid request_id format.",
         )
-    if config.mode != DistributedMode.KAFKA:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Stored results are only available in Kafka mode.",
-        )
     if response_format is None:
         response_format = config.default_response_format
+
+    if config.mode != DistributedMode.KAFKA:
+        stored = result_store.get(request_id)
+        if stored is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Result not available (not stored, expired, or result store disabled).",
+            )
+        return format_transcription(
+            stored, response_format, highlight_words=highlight_words
+        )
 
     raw = await s3_client.get_result(request_id)
     if raw is None:

--- a/src/whisperx_api_server/transcriber.py
+++ b/src/whisperx_api_server/transcriber.py
@@ -288,6 +288,8 @@ async def transcribe(
     align: bool = False,
     diarize: bool = False,
     speaker_embeddings: bool = False,
+    min_speakers: int | None = None,
+    max_speakers: int | None = None,
     request_id: str = "",
     task: str = "transcribe",
     source_url: str | None = None,
@@ -465,6 +467,8 @@ async def transcribe(
                     audio=audio,
                     speaker_embeddings=speaker_embeddings,
                     request_id=request_id,
+                    min_speakers=min_speakers,
+                    max_speakers=max_speakers,
                 )
                 profile["diarize"] = time.perf_counter() - t0
                 logger.debug(

--- a/src/whisperx_api_server/webui.py
+++ b/src/whisperx_api_server/webui.py
@@ -1,0 +1,66 @@
+"""Optional bundled web UI: a static mount of the webui/ build output.
+
+The UI is a thin client over the public API — it holds no server-side state
+and registers no API routes. Everything here is skipped entirely unless
+WEBUI__ENABLED=true (see config.WebUIConfig).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.responses import RedirectResponse
+from fastapi.staticfiles import StaticFiles
+
+from whisperx_api_server.config import Config
+
+logger = logging.getLogger(__name__)
+
+MOUNT_PATH = "/webui"
+
+
+def resolve_dist_dir(config: Config) -> Path:
+    """Locate the built UI assets (a directory containing index.html).
+
+    WEBUI__DIST_DIR wins when set; otherwise ./webui/dist relative to the
+    working directory (the Docker image layout), then webui/dist at the repo
+    root (source checkouts / editable installs).
+    """
+    if config.webui.dist_dir:
+        candidates = [Path(config.webui.dist_dir)]
+    else:
+        candidates = [
+            Path.cwd() / "webui" / "dist",
+            Path(__file__).resolve().parents[2] / "webui" / "dist",
+        ]
+
+    for candidate in candidates:
+        if (candidate / "index.html").is_file():
+            return candidate
+
+    tried = ", ".join(str(c) for c in candidates)
+    raise RuntimeError(
+        "WEBUI__ENABLED is set but no built UI was found (looked for index.html "
+        f"in: {tried}). Build it with `cd webui && npm ci && npm run build`, "
+        "rebuild the Docker image with `--build-arg BUILD_WEBUI=build`, or point "
+        "WEBUI__DIST_DIR at an existing build output."
+    )
+
+
+def mount_webui(app: FastAPI, config: Config) -> None:
+    """Serve the built UI at /webui/ and redirect / to it.
+
+    The mount is intentionally outside API-key auth: it serves only the public
+    HTML/JS bundle, and every API call the UI makes carries the key entered by
+    the user. Nothing here is added to the OpenAPI schema.
+    """
+    dist_dir = resolve_dist_dir(config)
+
+    @app.get("/", include_in_schema=False)
+    def webui_root_redirect() -> RedirectResponse:
+        return RedirectResponse(url=f"{MOUNT_PATH}/", status_code=307)
+
+    app.mount(MOUNT_PATH, StaticFiles(directory=dist_dir, html=True), name="webui")
+    logger.info("Web UI enabled at %s/ (assets: %s)", MOUNT_PATH, dist_dir)

--- a/src/whisperx_worker/processor.py
+++ b/src/whisperx_worker/processor.py
@@ -224,6 +224,8 @@ async def process_job(
                     audio=audio,
                     speaker_embeddings=params.get("speaker_embeddings", False),
                     request_id=job_id,
+                    min_speakers=params.get("min_speakers"),
+                    max_speakers=params.get("max_speakers"),
                 )
                 profile["diarize"] = time.perf_counter() - t0
                 logger.debug(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,28 +1,46 @@
 import io
+import os
+import tempfile
 import wave
 
 import httpx
 import numpy as np
 import pytest
 
-from fake_backends import fake_transcription, register_fake_backends
+from fake_backends import fake_diarization, fake_transcription, register_fake_backends
 from whisperx_api_server import request_status
 from whisperx_api_server.dependencies import get_config
 
 register_fake_backends()
+
+_RESULT_STORE_DIR = tempfile.mkdtemp(prefix="whisperx-test-results-")
 
 TEST_ENV_DEFAULTS = {
     "MODE": "direct",
     "BACKENDS__TRANSCRIPTION": "fake",
     "BACKENDS__ALIGNMENT": "fake",
     "BACKENDS__DIARIZATION": "fake",
+    "RESULT_STORE__DIR": _RESULT_STORE_DIR,
 }
+
+
+def _clear_result_store_dir() -> None:
+    try:
+        for name in os.listdir(_RESULT_STORE_DIR):
+            if name.endswith(".json"):
+                os.remove(os.path.join(_RESULT_STORE_DIR, name))
+    except OSError:
+        pass
+
+
 CONFIG_ENV_KEYS = (
     "API_KEY",
     "API_KEYS_FILE",
     "AUTH_REQUIRED",
     "METRICS_ENABLED",
     "METRICS__ENABLED",
+    "WEBUI__ENABLED",
+    "WEBUI__DIST_DIR",
 )
 
 
@@ -36,8 +54,11 @@ def reset_state():
     request_status._reset_for_tests()
     fake_transcription.calls.clear()
     fake_transcription.raise_exc = None
+    fake_diarization.calls.clear()
+    _clear_result_store_dir()
     yield
     request_status._reset_for_tests()
+    _clear_result_store_dir()
     get_config.cache_clear()
 
 

--- a/tests/fake_backends.py
+++ b/tests/fake_backends.py
@@ -57,6 +57,9 @@ class FakeAlignmentBackend:
 
 
 class FakeDiarizationBackend:
+    def __init__(self):
+        self.calls: list[dict[str, Any]] = []
+
     async def preload_default(self) -> None:
         pass
 
@@ -69,8 +72,9 @@ class FakeDiarizationBackend:
     async def unload_model(self, model_name: str) -> bool:
         return False
 
-    async def diarize(self, *, result, audio, speaker_embeddings, request_id):
-        return result
+    async def diarize(self, **kwargs: Any):
+        self.calls.append(kwargs)
+        return kwargs["result"]
 
 
 fake_transcription = FakeTranscriptionBackend()

--- a/tests/test_async_endpoint.py
+++ b/tests/test_async_endpoint.py
@@ -137,8 +137,8 @@ async def test_result_invalid_id_400(make_app):
     assert resp.status_code == 400
 
 
-async def test_result_direct_mode_404(make_app):
+async def test_result_direct_mode_unknown_404(make_app):
     async with _client(make_app(MODE="direct")) as c:
         resp = await c.get("/v1/audio/transcriptions/job-x/result")
     assert resp.status_code == 404
-    assert "kafka" in resp.json()["detail"].lower()
+    assert "not available" in resp.json()["detail"].lower()

--- a/tests/test_info_endpoint.py
+++ b/tests/test_info_endpoint.py
@@ -1,0 +1,21 @@
+"""GET /info: discoverability fields (upload cap, subtitle capability)."""
+
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_info_reports_unlimited_upload_by_default(client):
+    body = (await client.get("/info")).json()
+    assert body["max_upload_size_bytes"] is None
+    assert isinstance(body["subtitle_formats_available"], bool)
+
+
+async def test_info_reports_configured_upload_cap(make_app):
+    import httpx
+
+    app = make_app(MAX_UPLOAD_SIZE_BYTES="1048576")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        body = (await c.get("/info")).json()
+    assert body["max_upload_size_bytes"] == 1048576

--- a/tests/test_models_catalog.py
+++ b/tests/test_models_catalog.py
@@ -1,0 +1,30 @@
+"""GET /models/catalog: available in both modes, reports default + loaded."""
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+
+def _client(app):
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    )
+
+
+async def test_catalog_direct_mode(client):
+    body = (await client.get("/models/catalog")).json()
+    assert "large-v3" in body["models"]
+    assert "turbo" in body["models"]
+    assert body["default"] == "large-v3"
+    assert body["loaded"] == ["fake-tiny"]
+
+
+async def test_catalog_available_in_kafka_mode(make_app):
+    app = make_app(MODE="kafka")
+    async with _client(app) as c:
+        resp = await c.get("/models/catalog")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "large-v3" in body["models"]
+    assert body["loaded"] is None

--- a/tests/test_result_store.py
+++ b/tests/test_result_store.py
@@ -1,0 +1,121 @@
+"""Direct-mode on-disk result store: unit behavior + GET .../result wiring."""
+
+import os
+
+import httpx
+import pytest
+
+from whisperx_api_server import result_store
+from whisperx_api_server.dependencies import get_config
+
+pytestmark = pytest.mark.anyio
+
+RESULT = {"text": "hello world", "language": "en", "segments": []}
+
+
+def _configure(monkeypatch, tmp_path, **env):
+    for key, value in {"RESULT_STORE__DIR": str(tmp_path), **env}.items():
+        monkeypatch.setenv(key, str(value))
+    get_config.cache_clear()
+
+
+def test_put_get_roundtrip(monkeypatch, tmp_path):
+    _configure(monkeypatch, tmp_path)
+    result_store.put("rid-1", RESULT)
+    assert result_store.get("rid-1") == RESULT
+    assert result_store.get("missing") is None
+
+
+def test_disabled_is_noop(monkeypatch, tmp_path):
+    _configure(monkeypatch, tmp_path, RESULT_STORE__ENABLED="false")
+    result_store.put("rid-1", RESULT)
+    assert result_store.get("rid-1") is None
+
+
+def test_unsafe_id_ignored(monkeypatch, tmp_path):
+    _configure(monkeypatch, tmp_path)
+    result_store.put("../escape", RESULT)
+    assert result_store.get("../escape") is None
+    assert os.listdir(tmp_path) == []
+
+
+def test_ttl_expiry_on_read(monkeypatch, tmp_path):
+    _configure(monkeypatch, tmp_path, RESULT_STORE__TTL_SECONDS="300")
+    result_store.put("rid-1", RESULT)
+    path = tmp_path / "rid-1.json"
+    old = os.path.getmtime(path) - 3600
+    os.utime(path, (old, old))
+    assert result_store.get("rid-1") is None
+    assert not path.exists()
+
+
+def test_evict_expired(monkeypatch, tmp_path):
+    _configure(monkeypatch, tmp_path, RESULT_STORE__TTL_SECONDS="300")
+    result_store.put("rid-1", RESULT)
+    stored = os.path.getmtime(tmp_path / "rid-1.json")
+    assert result_store.evict_expired(now=stored + 301) == 1
+    assert result_store.get("rid-1") is None
+
+
+def test_capacity_trims_oldest(monkeypatch, tmp_path):
+    _configure(monkeypatch, tmp_path)
+    for i in range(3):
+        result_store.put(f"rid-{i}", RESULT)
+        path = tmp_path / f"rid-{i}.json"
+        os.utime(path, (1000 + i, 1000 + i))
+    result_store._enforce_capacity(str(tmp_path), 2)
+    remaining = sorted(os.listdir(tmp_path))
+    assert remaining == ["rid-1.json", "rid-2.json"]
+
+
+def _client(app):
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    )
+
+
+async def _run_direct(make_app, monkeypatch, tmp_path, **env):
+    import whisperx_api_server.transcriber as transcriber
+
+    async def fake(**kwargs):
+        return dict(RESULT)
+
+    monkeypatch.setattr(transcriber, "transcribe", fake)
+    return make_app(RESULT_STORE__DIR=str(tmp_path), **env)
+
+
+async def test_result_endpoint_serves_stored_result(make_app, monkeypatch, tmp_path):
+    app = await _run_direct(make_app, monkeypatch, tmp_path)
+    async with _client(app) as c:
+        post = await c.post(
+            "/v1/audio/transcriptions",
+            data={"audio_url": "http://example.com/a.wav", "align": "false"},
+            headers={"X-Request-ID": "stored-1"},
+        )
+        assert post.status_code == 200, post.text
+        got = await c.get(
+            "/v1/audio/transcriptions/stored-1/result?response_format=json"
+        )
+    assert got.status_code == 200, got.text
+    assert got.json() == {"text": "hello world"}
+
+
+async def test_result_endpoint_404_when_disabled(make_app, monkeypatch, tmp_path):
+    app = await _run_direct(
+        make_app, monkeypatch, tmp_path, RESULT_STORE__ENABLED="false"
+    )
+    async with _client(app) as c:
+        await c.post(
+            "/v1/audio/transcriptions",
+            data={"audio_url": "http://example.com/a.wav", "align": "false"},
+            headers={"X-Request-ID": "stored-2"},
+        )
+        got = await c.get("/v1/audio/transcriptions/stored-2/result")
+    assert got.status_code == 404
+
+
+async def test_result_endpoint_404_unknown(make_app, monkeypatch, tmp_path):
+    app = await _run_direct(make_app, monkeypatch, tmp_path)
+    async with _client(app) as c:
+        got = await c.get("/v1/audio/transcriptions/never-seen/result")
+    assert got.status_code == 404

--- a/tests/test_status_endpoint.py
+++ b/tests/test_status_endpoint.py
@@ -7,6 +7,7 @@ from whisperx_api_server import request_status
 pytestmark = pytest.mark.anyio
 
 STATUS = "/v1/audio/transcriptions/{}/status"
+EVENTS = "/v1/audio/transcriptions/{}/events"
 
 
 async def test_status_lifecycle(client):
@@ -36,6 +37,28 @@ async def test_status_unknown_id_404(client):
 
 async def test_status_invalid_id_400(client):
     resp = await client.get(STATUS.format("bad@id"))
+    assert resp.status_code == 400
+
+
+async def test_events_terminal_emits_and_closes(client):
+    rid = "job-events-1"
+    request_status.start(rid, mode="direct", filename="a.wav")
+    request_status.mark_completed(rid)
+
+    resp = await client.get(EVENTS.format(rid))
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    assert resp.text.startswith("data:")
+    assert "completed" in resp.text
+
+
+async def test_events_unknown_id_404(client):
+    resp = await client.get(EVENTS.format("never-seen"))
+    assert resp.status_code == 404
+
+
+async def test_events_invalid_id_400(client):
+    resp = await client.get(EVENTS.format("bad@id"))
     assert resp.status_code == 400
 
 

--- a/tests/test_transcriptions_endpoint.py
+++ b/tests/test_transcriptions_endpoint.py
@@ -230,6 +230,40 @@ async def test_callback_url_ssrf_rejected_422(make_app, monkeypatch):
     assert "callback_url" in resp.json()["detail"].lower()
 
 
+async def test_min_max_speakers_forwarded_to_transcribe(make_app, monkeypatch):
+    record: dict = {}
+    _patch_transcribe(monkeypatch, returns=dict(CANNED), record=record)
+    async with _client(make_app()) as c:
+        resp = await _post(
+            c,
+            audio_url="http://example.com/a.wav",
+            response_format="json",
+            diarize="true",
+            min_speakers="2",
+            max_speakers="4",
+        )
+    assert resp.status_code == 200, resp.text
+    assert record["min_speakers"] == 2
+    assert record["max_speakers"] == 4
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"min_speakers": "0"},
+        {"max_speakers": "0"},
+        {"min_speakers": "3", "max_speakers": "2"},
+    ],
+)
+async def test_invalid_speaker_bounds_422(make_app, monkeypatch, params):
+    _patch_transcribe(monkeypatch, returns=dict(CANNED))
+    async with _client(make_app()) as c:
+        resp = await _post(
+            c, audio_url="http://example.com/a.wav", align="false", **params
+        )
+    assert resp.status_code == 422, resp.text
+
+
 def test_json_canned_is_serializable():
     # Guards against an accidentally non-JSON canned payload in this module.
     json.dumps(CANNED)

--- a/tests/test_webui.py
+++ b/tests/test_webui.py
@@ -1,0 +1,104 @@
+"""Web UI static mount: off by default, opt-in via WEBUI__ENABLED, and inert
+with respect to the API contract when on."""
+
+import shutil
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+requires_ffmpeg = pytest.mark.skipif(
+    shutil.which("ffmpeg") is None, reason="ffmpeg not on PATH"
+)
+
+
+@pytest.fixture
+def webui_dist(tmp_path):
+    dist = tmp_path / "dist"
+    (dist / "assets").mkdir(parents=True)
+    (dist / "index.html").write_text(
+        "<!doctype html><title>whisperx webui</title>", encoding="utf-8"
+    )
+    (dist / "assets" / "app.js").write_text("console.log('webui')", encoding="utf-8")
+    return dist
+
+
+def webui_env(webui_dist) -> dict:
+    return {"WEBUI__ENABLED": "true", "WEBUI__DIST_DIR": str(webui_dist)}
+
+
+async def test_webui_disabled_by_default(client):
+    assert (await client.get("/webui/")).status_code == 404
+    assert (await client.get("/")).status_code == 404
+
+
+async def test_webui_enabled_serves_assets(make_app, webui_dist):
+    transport = httpx.ASGITransport(app=make_app(**webui_env(webui_dist)))
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        resp = await c.get("/webui/")
+        assert resp.status_code == 200
+        assert "whisperx webui" in resp.text
+
+        resp = await c.get("/webui/assets/app.js")
+        assert resp.status_code == 200
+
+        resp = await c.get("/")
+        assert resp.status_code == 307
+        assert resp.headers["location"] == "/webui/"
+
+
+async def test_webui_enabled_without_build_fails_fast(make_app, tmp_path):
+    empty = tmp_path / "nothing"
+    empty.mkdir()
+    with pytest.raises(RuntimeError, match="no built UI was found"):
+        make_app(WEBUI__ENABLED="true", WEBUI__DIST_DIR=str(empty))
+
+
+async def test_webui_static_assets_not_behind_auth(make_app, webui_dist):
+    app = make_app(API_KEY="sekret", **webui_env(webui_dist))
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        assert (await c.get("/webui/")).status_code == 200
+        # The API itself still requires the key.
+        resp = await c.post(
+            "/v1/audio/transcriptions",
+            data={"audio_url": "http://example.com/a.wav"},
+        )
+        assert resp.status_code == 401
+
+
+async def test_api_contract_identical_with_webui_enabled(make_app, webui_dist):
+    plain = make_app()
+    with_ui = make_app(**webui_env(webui_dist))
+
+    schemas = []
+    for app in (plain, with_ui):
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            health = await c.get("/healthcheck")
+            assert health.status_code == 200
+            assert health.json() == {"status": "healthy"}
+            schemas.append((await c.get("/openapi.json")).json())
+
+    assert schemas[0] == schemas[1]
+
+
+@requires_ffmpeg
+async def test_transcription_identical_with_webui_enabled(
+    make_app, webui_dist, sine_wav
+):
+    responses = []
+    for env in ({}, webui_env(webui_dist)):
+        transport = httpx.ASGITransport(app=make_app(**env))
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.post(
+                "/v1/audio/transcriptions",
+                files={"file": ("test.wav", sine_wav, "audio/wav")},
+                data={"align": "false", "response_format": "json"},
+            )
+            responses.append(resp)
+
+    assert responses[0].status_code == responses[1].status_code == 200
+    assert responses[0].json() == responses[1].json()
+    assert responses[0].headers["content-type"] == responses[1].headers["content-type"]

--- a/webui/.gitignore
+++ b/webui/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.local

--- a/webui/README.md
+++ b/webui/README.md
@@ -1,0 +1,36 @@
+# WhisperX Web UI
+
+Optional browser UI for whisperx-api-server. A thin client over the public
+OpenAI-compatible endpoints — it holds no state of its own and adds no API
+routes; the built assets are served by FastAPI under `/webui/` when
+`WEBUI__ENABLED=true`.
+
+## Build
+
+```bash
+bun install --frozen-lockfile
+bun run build     # emits dist/, picked up by the server at startup
+```
+
+## Develop
+
+```bash
+bun run dev       # Vite dev server on :5173, proxying API calls
+```
+
+API requests are proxied to `http://localhost:8000` (override with the
+`WEBUI_DEV_API` environment variable), so run the API server alongside.
+
+## Quality
+
+```bash
+bun run lint      # Biome — lint + format check
+bun run format    # Biome — apply formatting
+bun run test      # Vitest — unit + component tests
+```
+
+Requires Bun ≥ 1.3. Stack: React 19, Vite 8, TypeScript 7,
+Tailwind CSS v4 (semantic design-token theme with a light/dark toggle), Biome,
+Vitest + Testing Library. Colours are driven by role tokens (`bg-surface`,
+`text-fg`, `border-border`, …) defined in `src/index.css`, which flip under the
+`.dark` class — components carry no per-element `dark:` variants.

--- a/webui/biome.json
+++ b/webui/biome.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "includes": ["src/**/*.{ts,tsx}", "*.ts", "*.json"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 90
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double"
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "domains": {
+      "react": "recommended"
+    },
+    "rules": {
+      "preset": "recommended",
+      "correctness": {
+        "useExhaustiveDependencies": "warn",
+        "useHookAtTopLevel": "error"
+      }
+    }
+  }
+}

--- a/webui/bun.lock
+++ b/webui/bun.lock
@@ -1,0 +1,425 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 0,
+  "workspaces": {
+    "": {
+      "name": "whisperx-webui",
+      "dependencies": {
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^2.5.4",
+        "@tailwindcss/vite": "^4.3.3",
+        "@testing-library/jest-dom": "^7.0.0",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^6.0.3",
+        "jsdom": "^29.1.1",
+        "tailwindcss": "^4.3.3",
+        "typescript": "~7.0.2",
+        "vite": "^8.1.5",
+        "vitest": "^4.1.10",
+      },
+    },
+  },
+  "packages": {
+    "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],
+
+    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.11", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@csstools/css-calc": "^3.2.0", "@csstools/css-color-parser": "^4.1.0", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg=="],
+
+    "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@7.1.1", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1" } }, "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ=="],
+
+    "@asamuzakjp/generational-cache": ["@asamuzakjp/generational-cache@1.0.1", "", {}, "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg=="],
+
+    "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
+
+    "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
+    "@biomejs/biome": ["@biomejs/biome@2.5.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.4", "@biomejs/cli-darwin-x64": "2.5.4", "@biomejs/cli-linux-arm64": "2.5.4", "@biomejs/cli-linux-arm64-musl": "2.5.4", "@biomejs/cli-linux-x64": "2.5.4", "@biomejs/cli-linux-x64-musl": "2.5.4", "@biomejs/cli-win32-arm64": "2.5.4", "@biomejs/cli-win32-x64": "2.5.4" }, "bin": { "biome": "bin/biome" } }, "sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.4", "", { "os": "linux", "cpu": "x64" }, "sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.4", "", { "os": "linux", "cpu": "x64" }, "sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.4", "", { "os": "win32", "cpu": "x64" }, "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q=="],
+
+    "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
+
+    "@csstools/color-helpers": ["@csstools/color-helpers@6.1.0", "", {}, "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg=="],
+
+    "@csstools/css-calc": ["@csstools/css-calc@3.2.1", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg=="],
+
+    "@csstools/css-color-parser": ["@csstools/css-color-parser@4.1.9", "", { "dependencies": { "@csstools/color-helpers": "^6.1.0", "@csstools/css-calc": "^3.2.1" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A=="],
+
+    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@4.0.0", "", { "peerDependencies": { "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w=="],
+
+    "@csstools/css-syntax-patches-for-csstree": ["@csstools/css-syntax-patches-for-csstree@1.1.6", "", { "peerDependencies": { "css-tree": "^3.2.1" } }, "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ=="],
+
+    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
+
+    "@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
+
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
+
+    "@exodus/bytes": ["@exodus/bytes@1.15.1", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
+    "@oxc-project/types": ["@oxc-project/types@0.139.0", "", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
+
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.5", "", { "os": "android", "cpu": "arm64" }, "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.1.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.1.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.1.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.1.5", "", { "os": "linux", "cpu": "arm" }, "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA=="],
+
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.1.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.1.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg=="],
+
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.1.5", "", { "os": "none", "cpu": "arm64" }, "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw=="],
+
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.1.5", "", { "dependencies": { "@emnapi/core": "1.11.1", "@emnapi/runtime": "1.11.1", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.1.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.1.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@tailwindcss/node": ["@tailwindcss/node@4.3.3", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.24.1", "jiti": "^2.7.0", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.3" } }, "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg=="],
+
+    "@tailwindcss/oxide": ["@tailwindcss/oxide@4.3.3", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.3.3", "@tailwindcss/oxide-darwin-arm64": "4.3.3", "@tailwindcss/oxide-darwin-x64": "4.3.3", "@tailwindcss/oxide-freebsd-x64": "4.3.3", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3", "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3", "@tailwindcss/oxide-linux-arm64-musl": "4.3.3", "@tailwindcss/oxide-linux-x64-gnu": "4.3.3", "@tailwindcss/oxide-linux-x64-musl": "4.3.3", "@tailwindcss/oxide-wasm32-wasi": "4.3.3", "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3", "@tailwindcss/oxide-win32-x64-msvc": "4.3.3" } }, "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA=="],
+
+    "@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.3.3", "", { "os": "android", "cpu": "arm64" }, "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw=="],
+
+    "@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.3.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw=="],
+
+    "@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.3.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw=="],
+
+    "@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.3.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw=="],
+
+    "@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3", "", { "os": "linux", "cpu": "arm" }, "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ=="],
+
+    "@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.3.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w=="],
+
+    "@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.3.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA=="],
+
+    "@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.3.3", "", { "os": "linux", "cpu": "x64" }, "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w=="],
+
+    "@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.3.3", "", { "os": "linux", "cpu": "x64" }, "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img=="],
+
+    "@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.3.3", "", { "cpu": "none" }, "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ=="],
+
+    "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.3.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ=="],
+
+    "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.3.3", "", { "os": "win32", "cpu": "x64" }, "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw=="],
+
+    "@tailwindcss/vite": ["@tailwindcss/vite@4.3.3", "", { "dependencies": { "@tailwindcss/node": "4.3.3", "@tailwindcss/oxide": "4.3.3", "tailwindcss": "4.3.3" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw=="],
+
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/jest-dom": ["@testing-library/jest-dom@7.0.0", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" }, "peerDependencies": { "@testing-library/dom": ">=10 <11" } }, "sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg=="],
+
+    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
+
+    "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
+
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
+
+    "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
+
+    "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.3", "", { "dependencies": { "@rolldown/pluginutils": "^1.0.1" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg=="],
+
+    "@vitest/expect": ["@vitest/expect@4.1.10", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.10", "", { "dependencies": { "@vitest/spy": "4.1.10", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw"] }, "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.10", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.10", "", { "dependencies": { "@vitest/utils": "4.1.10", "pathe": "^2.0.3" } }, "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "@vitest/utils": "4.1.10", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.10", "", {}, "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
+    "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
+
+    "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
+
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
+
+    "enhanced-resolve": ["enhanced-resolve@5.24.3", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ=="],
+
+    "entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
+
+    "es-module-lexer": ["es-module-lexer@2.3.1", "", {}, "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
+
+    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
+
+    "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
+    "jiti": ["jiti@2.7.0", "", { "bin": "lib/jiti-cli.mjs" }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "jsdom": ["jsdom@29.1.1", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.11", "@asamuzakjp/dom-selector": "^7.1.1", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.3", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.3.5", "parse5": "^8.0.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.25.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q=="],
+
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
+
+    "lz-string": ["lz-string@1.5.0", "", { "bin": "bin/bin.js" }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
+
+    "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
+
+    "nanoid": ["nanoid@3.3.16", "", { "bin": "bin/nanoid.cjs" }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+
+    "obug": ["obug@2.1.4", "", {}, "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="],
+
+    "parse5": ["parse5@8.0.1", "", { "dependencies": { "entities": "^8.0.0" } }, "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
+    "postcss": ["postcss@8.5.20", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug=="],
+
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
+
+    "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
+    "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "rolldown": ["rolldown@1.1.5", "", { "dependencies": { "@oxc-project/types": "=0.139.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.5", "@rolldown/binding-darwin-arm64": "1.1.5", "@rolldown/binding-darwin-x64": "1.1.5", "@rolldown/binding-freebsd-x64": "1.1.5", "@rolldown/binding-linux-arm-gnueabihf": "1.1.5", "@rolldown/binding-linux-arm64-gnu": "1.1.5", "@rolldown/binding-linux-arm64-musl": "1.1.5", "@rolldown/binding-linux-ppc64-gnu": "1.1.5", "@rolldown/binding-linux-s390x-gnu": "1.1.5", "@rolldown/binding-linux-x64-gnu": "1.1.5", "@rolldown/binding-linux-x64-musl": "1.1.5", "@rolldown/binding-openharmony-arm64": "1.1.5", "@rolldown/binding-wasm32-wasi": "1.1.5", "@rolldown/binding-win32-arm64-msvc": "1.1.5", "@rolldown/binding-win32-x64-msvc": "1.1.5" }, "bin": "bin/cli.mjs" }, "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA=="],
+
+    "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@4.2.0", "", {}, "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="],
+
+    "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
+
+    "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
+
+    "tailwindcss": ["tailwindcss@4.3.3", "", {}, "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ=="],
+
+    "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
+
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
+
+    "tldts": ["tldts@7.4.9", "", { "dependencies": { "tldts-core": "^7.4.9" }, "bin": "bin/cli.js" }, "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA=="],
+
+    "tldts-core": ["tldts-core@7.4.9", "", {}, "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg=="],
+
+    "tough-cookie": ["tough-cookie@6.0.2", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA=="],
+
+    "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
+
+    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+
+    "vite": ["vite@8.1.5", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.5", "postcss": "^8.5.17", "rolldown": "~1.1.5", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": "bin/vite.js" }, "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw=="],
+
+    "vitest": ["vitest@4.1.10", "", { "dependencies": { "@vitest/expect": "4.1.10", "@vitest/mocker": "4.1.10", "@vitest/pretty-format": "4.1.10", "@vitest/runner": "4.1.10", "@vitest/snapshot": "4.1.10", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.10", "@vitest/browser-preview": "4.1.10", "@vitest/browser-webdriverio": "4.1.10", "@vitest/coverage-istanbul": "4.1.10", "@vitest/coverage-v8": "4.1.10", "@vitest/ui": "4.1.10", "happy-dom": "*", "jsdom": "*", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom"], "bin": "vitest.mjs" }, "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw=="],
+
+    "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
+
+    "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
+
+    "whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": "cli.js" }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
+
+    "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
+
+    "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+  }
+}

--- a/webui/index.html
+++ b/webui/index.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
+    <script>
+      // Apply the saved (or OS) theme before first paint to avoid a flash.
+      (function () {
+        try {
+          var t = localStorage.getItem("whisperx-webui-theme");
+          if (t !== "light" && t !== "dark") {
+            t = window.matchMedia("(prefers-color-scheme: dark)").matches
+              ? "dark"
+              : "light";
+          }
+          document.documentElement.classList.toggle("dark", t === "dark");
+          document.documentElement.style.colorScheme = t;
+        } catch (e) {}
+      })();
+    </script>
+    <link
+      rel="icon"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='3' fill='%2322d3ee'/%3E%3Cg stroke='%2306232b' stroke-width='2.5' stroke-linecap='round'%3E%3Cpath d='M8 13v6'/%3E%3Cpath d='M13 9v14'/%3E%3Cpath d='M18 12v8'/%3E%3Cpath d='M24 14v4'/%3E%3C/g%3E%3C/svg%3E"
+    />
+    <title>WhisperX — Transcription</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "whisperx-webui",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "engines": {
+    "bun": ">=1.3.0"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview",
+    "lint": "biome check .",
+    "format": "biome format --write .",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.5.4",
+    "@tailwindcss/vite": "^4.3.3",
+    "@testing-library/jest-dom": "^7.0.0",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.3",
+    "jsdom": "^29.1.1",
+    "tailwindcss": "^4.3.3",
+    "typescript": "~7.0.2",
+    "vite": "^8.1.5",
+    "vitest": "^4.1.10"
+  }
+}

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -1,0 +1,261 @@
+import { useEffect, useState } from "react";
+
+import { getModelCatalog } from "./api/client";
+import { ApiKeyGate } from "./components/ApiKeyGate";
+import { DocsLinks } from "./components/DocsLinks";
+import { ErrorPanel } from "./components/ErrorPanel";
+import { FileDrop } from "./components/FileDrop";
+import { OptionsPanel } from "./components/OptionsPanel";
+import { ResultView } from "./components/ResultView";
+import { StagesPanel } from "./components/StagesPanel";
+import { ThemeToggle } from "./components/ThemeToggle";
+import { useToasts } from "./components/Toast";
+import { Button, Spinner } from "./components/ui";
+import { useServerConnection } from "./hooks/useServerConnection";
+import { useStoredOptions } from "./hooks/useStoredOptions";
+import { useTranscriptionJob } from "./hooks/useTranscriptionJob";
+import { useUnloadWarning } from "./hooks/useUnloadWarning";
+import { useWindowDrop } from "./hooks/useWindowDrop";
+import { validateFile } from "./lib/files";
+
+function Logo() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 32 32" className="h-6 w-6">
+      <rect width="32" height="32" rx="3" fill="#22d3ee" />
+      <g stroke="#06232b" strokeWidth="2.5" strokeLinecap="round">
+        <path d="M8 13v6" />
+        <path d="M13 9v14" />
+        <path d="M18 12v8" />
+        <path d="M24 14v4" />
+      </g>
+    </svg>
+  );
+}
+
+export default function App() {
+  const connection = useServerConnection();
+  const mode = connection.info?.mode ?? null;
+  const job = useTranscriptionJob(connection.apiKey, mode);
+
+  const [options, setOptions] = useStoredOptions();
+  const [file, setFile] = useState<File | null>(null);
+  const [modelSuggestions, setModelSuggestions] = useState<string[]>([]);
+  const maxUploadBytes = connection.info?.max_upload_size_bytes ?? null;
+
+  useEffect(() => {
+    if (connection.phase !== "ready") return;
+    let alive = true;
+    void getModelCatalog(connection.apiKey).then((catalog) => {
+      if (alive) setModelSuggestions([...(catalog.loaded ?? []), ...catalog.models]);
+    });
+    return () => {
+      alive = false;
+    };
+  }, [connection.phase, connection.apiKey]);
+
+  const running = job.state.phase === "uploading" || job.state.phase === "processing";
+  const ready = connection.phase === "ready";
+  const canStart = ready && file !== null && !running;
+
+  const startJob = () => {
+    if (file) job.start(file, options);
+  };
+  const retryJob = () => {
+    if (job.state.file) job.start(job.state.file, options);
+  };
+
+  const { toast } = useToasts();
+  const acceptFile = (f: File) => {
+    const verdict = validateFile(f, maxUploadBytes);
+    if (!verdict.ok) {
+      toast(verdict.reason, "error");
+      return;
+    }
+    if (job.state.phase === "completed" || job.state.phase === "failed") job.reset();
+    setFile(f);
+    if (verdict.warning) toast(verdict.warning, "info");
+  };
+  const externalDragging = useWindowDrop(ready && !running, acceptFile);
+
+  // A reload/close can't restore the picked audio file, so warn before losing a
+  // running or finished transcription.
+  useUnloadWarning(running || job.state.phase === "completed");
+
+  return (
+    <div className="min-h-screen bg-canvas text-fg">
+      <header className="border-b border-border bg-surface">
+        <div className="mx-auto flex max-w-5xl flex-wrap items-center gap-x-3 gap-y-2 px-4 py-3">
+          <Logo />
+          <h1 className="flex items-center text-lg font-semibold lowercase tracking-tight">
+            whisperx
+            <span className="term-cursor ml-1" aria-hidden="true" />
+          </h1>
+          {connection.info ? (
+            <span className="rounded-sm bg-surface-2 px-2 py-0.5 text-[11px] tabular-nums text-fg-muted">
+              v{connection.info.version} · {connection.info.mode} mode
+            </span>
+          ) : null}
+          <div className="ml-auto flex items-center gap-2 text-xs text-fg-muted">
+            {connection.phase === "connecting" ? (
+              <>
+                <Spinner className="text-fg-subtle" /> connecting
+              </>
+            ) : connection.phase === "ready" ? (
+              <>
+                <span className="h-2 w-2 bg-success" aria-hidden="true" />
+                connected
+                {connection.authRequired ? (
+                  <button
+                    type="button"
+                    onClick={connection.clearKey}
+                    className="text-accent-text underline-offset-2 hover:underline"
+                  >
+                    change key
+                  </button>
+                ) : null}
+              </>
+            ) : (
+              <>
+                <span className="h-2 w-2 bg-danger-text" aria-hidden="true" />
+                {connection.phase === "need-key" ? "key required" : "offline"}
+              </>
+            )}
+          </div>
+          <DocsLinks />
+          <ThemeToggle />
+        </div>
+      </header>
+
+      {connection.phase === "unreachable" ? (
+        <main className="mx-auto max-w-5xl px-4 py-8">
+          <section
+            role="alert"
+            className="rounded-sm border border-danger-border bg-danger-bg p-5"
+          >
+            <h2 className="text-base font-semibold text-danger-strong">
+              server unreachable
+            </h2>
+            <p className="mt-1 text-sm text-danger-text">
+              Could not reach the API on this origin. Is the server running?
+            </p>
+            <Button variant="secondary" className="mt-3" onClick={connection.retry}>
+              Retry
+            </Button>
+          </section>
+        </main>
+      ) : connection.phase === "need-key" ? (
+        <main className="mx-auto max-w-5xl px-4 py-8">
+          <ApiKeyGate connection={connection} />
+        </main>
+      ) : (
+        <main className="mx-auto grid max-w-5xl gap-6 px-4 py-8 lg:grid-cols-[320px_minmax(0,1fr)]">
+          <aside className="lg:sticky lg:top-6 lg:self-start">
+            <div className="rounded-sm border border-border bg-surface">
+              <h2 className="border-b border-border px-4 py-2.5 text-sm font-semibold text-fg">
+                Options
+              </h2>
+              <div className="p-4">
+                <OptionsPanel
+                  options={options}
+                  onChange={setOptions}
+                  modelSuggestions={modelSuggestions}
+                  disabled={running}
+                />
+              </div>
+            </div>
+          </aside>
+
+          <div className="flex min-w-0 flex-col gap-6">
+            {job.state.phase === "completed" &&
+            job.state.result &&
+            job.state.file &&
+            job.state.requestId &&
+            job.state.options ? (
+              <ResultView
+                payload={job.state.result}
+                file={job.state.file}
+                options={job.state.options}
+                requestId={job.state.requestId}
+                subtitleAvailable={connection.info?.subtitle_formats_available ?? true}
+                apiKey={connection.apiKey}
+                durationSeconds={
+                  job.state.finishedAtMs !== null && job.state.startedAtMs !== null
+                    ? (job.state.finishedAtMs - job.state.startedAtMs) / 1000
+                    : null
+                }
+                optionsChanged={
+                  JSON.stringify(options) !== JSON.stringify(job.state.options)
+                }
+                onRerun={retryJob}
+                onReset={() => {
+                  job.reset();
+                  setFile(null);
+                }}
+              />
+            ) : running ? (
+              <StagesPanel
+                phase={job.state.phase}
+                status={job.state.status}
+                uploadProgress={job.state.uploadProgress}
+                requestId={job.state.requestId}
+                fileName={job.state.file?.name ?? null}
+                startedAtMs={job.state.startedAtMs}
+                onCancel={job.cancel}
+              />
+            ) : job.state.phase === "failed" && job.state.error ? (
+              <ErrorPanel
+                error={job.state.error}
+                status={job.state.status}
+                requestId={job.state.requestId}
+                onRetry={job.state.file ? retryJob : null}
+                onReset={() => {
+                  job.reset();
+                  setFile(null);
+                }}
+              />
+            ) : (
+              <section aria-label="New transcription" className="flex flex-col gap-4">
+                <div className="flex flex-col gap-1">
+                  <h2 className="text-lg font-semibold tracking-tight text-fg">
+                    transcribe audio &amp; video
+                  </h2>
+                  <p className="text-sm text-fg-muted">
+                    drop a file, set options, run — OpenAI-compatible WhisperX on this
+                    origin.
+                  </p>
+                </div>
+                <FileDrop
+                  file={file}
+                  onSelect={setFile}
+                  disabled={!ready}
+                  maxUploadBytes={maxUploadBytes}
+                />
+                <div className="flex items-center gap-3">
+                  <Button disabled={!canStart} onClick={startJob}>
+                    Transcribe
+                  </Button>
+                  {!file ? (
+                    <p className="text-sm text-fg-muted">select a file to get started.</p>
+                  ) : null}
+                </div>
+              </section>
+            )}
+          </div>
+        </main>
+      )}
+
+      <footer className="mx-auto max-w-5xl px-4 pb-8 text-[11px] text-fg-subtle">
+        thin client over the OpenAI-compatible WhisperX API on this origin — no data
+        leaves this server.
+      </footer>
+
+      {externalDragging ? (
+        <div className="pointer-events-none fixed inset-0 z-40 flex items-center justify-center bg-canvas/80 backdrop-blur-sm">
+          <div className="rounded-sm border-2 border-dashed border-accent bg-surface px-8 py-6 text-center">
+            <p className="text-sm font-medium text-fg">drop to load</p>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/webui/src/api/client.ts
+++ b/webui/src/api/client.ts
@@ -1,0 +1,253 @@
+/**
+ * Thin client over the whisperx-api-server HTTP API. Same-origin (the UI is
+ * served by the API), so no base URL and no CORS concerns.
+ */
+
+import type { ModelCatalog, RequestStatus, ServerInfo } from "./types";
+
+export class ApiError extends Error {
+  /** HTTP status; 0 for network failures, -1 for a client-side abort. */
+  readonly status: number;
+  readonly errorType: string | null;
+
+  constructor(message: string, status: number, errorType: string | null = null) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.errorType = errorType;
+  }
+}
+
+export function isAbort(e: unknown): boolean {
+  return e instanceof ApiError && e.status === -1;
+}
+
+export function isNetworkError(e: unknown): boolean {
+  return e instanceof ApiError && e.status === 0;
+}
+
+function authHeaders(apiKey: string | null): Record<string, string> {
+  return apiKey ? { Authorization: `Bearer ${apiKey}` } : {};
+}
+
+/** FastAPI error bodies: {"detail": string | ValidationError[]}. */
+function detailFromBody(body: string, fallback: string): string {
+  try {
+    const parsed = JSON.parse(body);
+    const detail = parsed?.detail;
+    if (typeof detail === "string") return detail;
+    if (Array.isArray(detail)) {
+      return detail
+        .map((d) => (typeof d?.msg === "string" ? d.msg : JSON.stringify(d)))
+        .join("; ");
+    }
+  } catch {
+    /* not JSON */
+  }
+  return fallback;
+}
+
+async function throwForResponse(resp: Response): Promise<never> {
+  const body = await resp.text().catch(() => "");
+  throw new ApiError(detailFromBody(body, `HTTP ${resp.status}`), resp.status, null);
+}
+
+/**
+ * Request id sent as X-Request-ID; must match the server's [A-Za-z0-9._-]{1,128}.
+ * crypto.randomUUID is unavailable in non-secure contexts (plain-HTTP LAN
+ * deployments), hence the fallback.
+ */
+export function newRequestId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  const alphabet = "abcdefghijklmnopqrstuvwxyz0123456789";
+  let suffix = "";
+  for (let i = 0; i < 20; i++) {
+    suffix += alphabet[Math.floor(Math.random() * alphabet.length)];
+  }
+  return `webui-${Date.now().toString(36)}-${suffix}`;
+}
+
+export type InfoResult =
+  | { ok: true; info: ServerInfo }
+  | { ok: false; status: number | null };
+
+export async function getInfo(apiKey: string | null): Promise<InfoResult> {
+  try {
+    const resp = await fetch("/info", { headers: authHeaders(apiKey) });
+    if (resp.ok) return { ok: true, info: (await resp.json()) as ServerInfo };
+    return { ok: false, status: resp.status };
+  } catch {
+    return { ok: false, status: null };
+  }
+}
+
+/** Null on any failure — the status poller treats misses as "not yet visible". */
+export async function getStatus(
+  requestId: string,
+  apiKey: string | null,
+): Promise<RequestStatus | null> {
+  try {
+    const resp = await fetch(
+      `/v1/audio/transcriptions/${encodeURIComponent(requestId)}/status`,
+      { headers: authHeaders(apiKey) },
+    );
+    if (!resp.ok) return null;
+    return (await resp.json()) as RequestStatus;
+  } catch {
+    return null;
+  }
+}
+
+export async function getModelCatalog(apiKey: string | null): Promise<ModelCatalog> {
+  const empty: ModelCatalog = { models: [], default: null, loaded: null };
+  try {
+    const resp = await fetch("/models/catalog", { headers: authHeaders(apiKey) });
+    if (!resp.ok) return empty;
+    const parsed = await resp.json();
+    const strings = (v: unknown): string[] =>
+      Array.isArray(v) ? v.filter((m): m is string => typeof m === "string") : [];
+    return {
+      models: strings(parsed?.models),
+      default: typeof parsed?.default === "string" ? parsed.default : null,
+      loaded: Array.isArray(parsed?.loaded) ? strings(parsed.loaded) : null,
+    };
+  } catch {
+    return empty;
+  }
+}
+
+export async function streamStatusEvents(
+  requestId: string,
+  apiKey: string | null,
+  opts: { onStatus: (status: RequestStatus) => void; signal?: AbortSignal },
+): Promise<void> {
+  const resp = await fetch(
+    `/v1/audio/transcriptions/${encodeURIComponent(requestId)}/events`,
+    { headers: authHeaders(apiKey), signal: opts.signal },
+  );
+  if (!resp.ok || !resp.body) {
+    throw new ApiError(`HTTP ${resp.status}`, resp.status);
+  }
+
+  const reader = resp.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    for (;;) {
+      const sep = buffer.indexOf("\n\n");
+      if (sep === -1) break;
+      const event = buffer.slice(0, sep);
+      buffer = buffer.slice(sep + 2);
+      const data = event
+        .split("\n")
+        .filter((line) => line.startsWith("data:"))
+        .map((line) => line.slice(5).trim())
+        .join("\n");
+      if (!data || data === "{}") continue;
+      let status: RequestStatus | null = null;
+      try {
+        status = JSON.parse(data) as RequestStatus;
+      } catch {
+        status = null;
+      }
+      if (status) opts.onStatus(status);
+    }
+  }
+}
+
+export interface PostHandle {
+  promise: Promise<{ contentType: string; body: string }>;
+  abort: () => void;
+}
+
+/**
+ * POST /v1/audio/transcriptions via XHR — fetch() cannot report upload
+ * progress, and multi-hundred-MB media files make that progress the main
+ * feedback during the first phase of a job.
+ */
+export function postTranscription(opts: {
+  file: File;
+  fields: Record<string, string | string[]>;
+  requestId: string;
+  apiKey: string | null;
+  onUploadProgress?: (fraction: number | null) => void;
+  onUploadComplete?: () => void;
+}): PostHandle {
+  const xhr = new XMLHttpRequest();
+
+  const promise = new Promise<{ contentType: string; body: string }>(
+    (resolve, reject) => {
+      const form = new FormData();
+      form.append("file", opts.file, opts.file.name);
+      for (const [key, value] of Object.entries(opts.fields)) {
+        if (Array.isArray(value)) {
+          for (const item of value) form.append(key, item);
+        } else {
+          form.append(key, value);
+        }
+      }
+
+      xhr.open("POST", "/v1/audio/transcriptions");
+      xhr.setRequestHeader("X-Request-ID", opts.requestId);
+      if (opts.apiKey) {
+        xhr.setRequestHeader("Authorization", `Bearer ${opts.apiKey}`);
+      }
+
+      xhr.upload.onprogress = (e) => {
+        opts.onUploadProgress?.(e.lengthComputable ? e.loaded / e.total : null);
+      };
+      // Fires once the request body is fully sent — the point at which the
+      // server registers the request, so status polling can begin without 404s.
+      xhr.upload.onload = () => opts.onUploadComplete?.();
+      xhr.onload = () => {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          resolve({
+            contentType: xhr.getResponseHeader("Content-Type") ?? "",
+            body: xhr.responseText,
+          });
+        } else {
+          reject(
+            new ApiError(
+              detailFromBody(xhr.responseText, `HTTP ${xhr.status}`),
+              xhr.status,
+            ),
+          );
+        }
+      };
+      xhr.onerror = () => reject(new ApiError("Network error", 0));
+      xhr.ontimeout = () => reject(new ApiError("Network timeout", 0));
+      xhr.onabort = () => reject(new ApiError("Cancelled", -1, "cancelled"));
+
+      xhr.send(form);
+    },
+  );
+
+  return { promise, abort: () => xhr.abort() };
+}
+
+/** GET /v1/audio/transcriptions/{id}/result — re-formats a finished job (both modes). */
+export async function fetchStoredResult(
+  requestId: string,
+  responseFormat: string,
+  highlightWords: boolean,
+  apiKey: string | null,
+): Promise<{ contentType: string; body: string }> {
+  const params = new URLSearchParams({
+    response_format: responseFormat,
+    highlight_words: String(highlightWords),
+  });
+  const resp = await fetch(
+    `/v1/audio/transcriptions/${encodeURIComponent(requestId)}/result?${params}`,
+    { headers: authHeaders(apiKey) },
+  );
+  if (!resp.ok) await throwForResponse(resp);
+  return {
+    contentType: resp.headers.get("Content-Type") ?? "",
+    body: await resp.text(),
+  };
+}

--- a/webui/src/api/types.ts
+++ b/webui/src/api/types.ts
@@ -1,0 +1,72 @@
+/** Shapes returned by the whisperx-api-server endpoints the UI consumes. */
+
+export interface WordTiming {
+  word: string;
+  /** Absent on tokens the aligner could not time (e.g. numerals). */
+  start?: number;
+  end?: number;
+  score?: number;
+  speaker?: string;
+}
+
+export interface Segment {
+  start: number;
+  end: number;
+  text: string;
+  speaker?: string;
+  words?: WordTiming[];
+}
+
+/**
+ * verbose_json / vtt_json payload. After alignment the server nests the
+ * segment list: `segments` is then `{segments: [...], word_segments: [...]}`.
+ */
+export interface VerbosePayload {
+  segments?:
+    | Segment[]
+    | { segments?: Segment[]; word_segments?: WordTiming[]; [k: string]: unknown };
+  language?: string;
+  text?: string;
+  /** Present only for response_format=vtt_json. */
+  vtt_text?: string;
+  [k: string]: unknown;
+}
+
+export interface StageEntry {
+  name: string;
+  started_at?: number;
+  completed_at?: number;
+  duration_seconds?: number;
+  in_progress?: boolean;
+}
+
+export type JobStatusValue = "queued" | "in_progress" | "completed" | "failed";
+
+export interface RequestStatus {
+  request_id: string;
+  status: JobStatusValue;
+  mode: string;
+  stage: string;
+  submitted_at: number;
+  updated_at: number;
+  completed_at: number | null;
+  filename: string | null;
+  stages: StageEntry[];
+  error: string | null;
+  error_type: string | null;
+}
+
+export interface ServerInfo {
+  version: string;
+  mode: string;
+  uptime_seconds: number;
+  max_upload_size_bytes?: number | null;
+  subtitle_formats_available?: boolean;
+  [k: string]: unknown;
+}
+
+export interface ModelCatalog {
+  models: string[];
+  default: string | null;
+  loaded: string[] | null;
+}

--- a/webui/src/components/ApiKeyGate.tsx
+++ b/webui/src/components/ApiKeyGate.tsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+
+import type { ServerConnection } from "../hooks/useServerConnection";
+import { Button, Field, inputClass, Toggle } from "./ui";
+
+export function ApiKeyGate(props: { connection: ServerConnection }) {
+  const { connection } = props;
+  const [key, setKey] = useState("");
+  const [remember, setRemember] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+
+  return (
+    <form
+      className="flex flex-col gap-3 rounded-sm border border-warn-border bg-warn-bg p-4"
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (!key.trim()) return;
+        setSubmitting(true);
+        void connection.submitKey(key.trim(), remember).finally(() => {
+          setSubmitting(false);
+        });
+      }}
+    >
+      <p className="text-sm text-warn-strong">This server requires an API key.</p>
+      <Field id="api-key" label="API key">
+        <input
+          id="api-key"
+          type="password"
+          autoComplete="off"
+          className={inputClass}
+          value={key}
+          onChange={(e) => setKey(e.target.value)}
+        />
+      </Field>
+      <Toggle
+        id="api-key-remember"
+        label="Remember in this browser"
+        checked={remember}
+        onChange={setRemember}
+      />
+      {connection.keyError ? (
+        <p role="alert" className="text-sm text-danger-text">
+          {connection.keyError}
+        </p>
+      ) : null}
+      <Button type="submit" disabled={submitting || !key.trim()}>
+        {submitting ? "Checking…" : "Connect"}
+      </Button>
+    </form>
+  );
+}

--- a/webui/src/components/DocsLinks.tsx
+++ b/webui/src/components/DocsLinks.tsx
@@ -1,0 +1,30 @@
+// FastAPI serves interactive API docs at /docs (Swagger UI) and /redoc (ReDoc)
+// on this same origin — absolute paths so they resolve from under /webui/.
+const linkClass =
+  "rounded-sm px-2 py-1 text-xs font-medium text-fg-muted hover:bg-surface-2 hover:text-fg " +
+  "focus:outline-none focus-visible:ring-2 focus-visible:ring-focus";
+
+export function DocsLinks() {
+  return (
+    <nav aria-label="API documentation" className="flex items-center gap-0.5">
+      <a
+        href="/docs"
+        target="_blank"
+        rel="noopener noreferrer"
+        title="Interactive API reference (Swagger UI)"
+        className={linkClass}
+      >
+        Swagger
+      </a>
+      <a
+        href="/redoc"
+        target="_blank"
+        rel="noopener noreferrer"
+        title="API reference (ReDoc)"
+        className={linkClass}
+      >
+        ReDoc
+      </a>
+    </nav>
+  );
+}

--- a/webui/src/components/ErrorBoundary.tsx
+++ b/webui/src/components/ErrorBoundary.tsx
@@ -1,0 +1,45 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+import { Button } from "./ui";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  error: Error | null;
+}
+
+/** Catches render-time errors so a component crash shows a recoverable message
+ * instead of a blank page. */
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error("Web UI crashed:", error, info);
+  }
+
+  render(): ReactNode {
+    if (!this.state.error) return this.props.children;
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-canvas p-6 text-fg">
+        <div className="max-w-lg text-center">
+          <h1 className="text-lg font-semibold">Something went wrong</h1>
+          <p className="mt-2 text-sm text-fg-muted">
+            The interface hit an unexpected error. Reloading usually fixes it.
+          </p>
+          <pre className="mt-3 overflow-auto rounded-md bg-surface-2 p-3 text-left text-xs text-danger-text">
+            {this.state.error.message}
+          </pre>
+          <Button className="mt-4" onClick={() => window.location.reload()}>
+            Reload
+          </Button>
+        </div>
+      </div>
+    );
+  }
+}

--- a/webui/src/components/ErrorPanel.tsx
+++ b/webui/src/components/ErrorPanel.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useRef } from "react";
+
+import type { RequestStatus } from "../api/types";
+import type { JobError } from "../hooks/useTranscriptionJob";
+import { prettyStageName } from "../lib/format";
+import { Button, CopyButton } from "./ui";
+
+export function ErrorPanel(props: {
+  error: JobError;
+  status: RequestStatus | null;
+  requestId: string | null;
+  onRetry: (() => void) | null;
+  onReset: () => void;
+}) {
+  const { error, status } = props;
+  const cancelled = error.cancelled;
+  // Prefer the tracker's error detail when the HTTP layer only had a generic one.
+  const message =
+    !cancelled && status?.error && error.message.startsWith("HTTP ")
+      ? status.error
+      : error.message;
+  const failedStage =
+    status && status.stages.length > 0
+      ? prettyStageName(status.stages[status.stages.length - 1].name).label
+      : null;
+
+  const headingRef = useRef<HTMLHeadingElement>(null);
+  useEffect(() => {
+    headingRef.current?.focus();
+  }, []);
+
+  return (
+    <section
+      role="alert"
+      className={`rounded-sm border p-5 ${
+        cancelled ? "border-border bg-surface" : "border-danger-border bg-danger-bg"
+      }`}
+    >
+      <div className="mb-2 flex flex-wrap items-center gap-2">
+        <h2
+          ref={headingRef}
+          tabIndex={-1}
+          className={`text-base font-semibold focus:outline-none ${
+            cancelled ? "text-fg" : "text-danger-strong"
+          }`}
+        >
+          {cancelled ? "Cancelled" : "Transcription failed"}
+        </h2>
+        {error.errorType && !cancelled ? (
+          <span className="rounded bg-danger-bg px-1.5 py-0.5 text-[11px] text-danger-strong">
+            {error.errorType}
+          </span>
+        ) : null}
+      </div>
+      <p className={`text-sm ${cancelled ? "text-fg-muted" : "text-danger-text"}`}>
+        {message}
+      </p>
+      {failedStage && !cancelled ? (
+        <p className="mt-1 text-xs text-danger-text">Last stage: {failedStage}</p>
+      ) : null}
+      {props.requestId ? (
+        <p className="mt-2 flex items-center gap-1.5 text-[11px] text-fg-subtle">
+          Request ID: <code>{props.requestId}</code>
+          <CopyButton value={props.requestId} />
+        </p>
+      ) : null}
+      <div className="mt-4 flex gap-2">
+        {props.onRetry ? <Button onClick={props.onRetry}>Try again</Button> : null}
+        <Button variant="secondary" onClick={props.onReset}>
+          Start over
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/webui/src/components/ExportBar.tsx
+++ b/webui/src/components/ExportBar.tsx
@@ -1,0 +1,101 @@
+import { useState } from "react";
+
+import { fetchStoredResult } from "../api/client";
+import type { VerbosePayload } from "../api/types";
+import { downloadFile, exportFileName, exportMime, planExport } from "../lib/exports";
+import {
+  RESPONSE_FORMATS,
+  type ResponseFormat,
+  type TranscriptionOptions,
+} from "../lib/options";
+import { useToasts } from "./Toast";
+import { Button, Spinner } from "./ui";
+
+function DownloadIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      className="h-3.5 w-3.5"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14" />
+    </svg>
+  );
+}
+
+export function ExportBar(props: {
+  payload: VerbosePayload;
+  requestId: string;
+  file: File;
+  options: TranscriptionOptions;
+  subtitleAvailable: boolean;
+  apiKey: string | null;
+}) {
+  const [busy, setBusy] = useState<ResponseFormat | null>(null);
+  const { toast } = useToasts();
+
+  const plan = (format: ResponseFormat) =>
+    planExport(format, {
+      payload: props.payload,
+      align: props.options.align,
+      subtitleAvailable: props.subtitleAvailable,
+    });
+
+  const doExport = async (format: ResponseFormat) => {
+    const p = plan(format);
+    const name = exportFileName(props.file.name, format);
+
+    if (p.kind === "unavailable") {
+      toast(p.reason, "error");
+      return;
+    }
+    if (p.kind === "local") {
+      downloadFile(name, p.content, p.mime);
+      return;
+    }
+
+    setBusy(format);
+    try {
+      const { body } = await fetchStoredResult(
+        props.requestId,
+        format,
+        props.options.highlightWords,
+        props.apiKey,
+      );
+      downloadFile(name, body, exportMime(format));
+      toast(`Downloaded ${name}`, "success");
+    } catch (e) {
+      toast(`Export failed: ${e instanceof Error ? e.message : String(e)}`, "error");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <fieldset>
+      <legend className="mb-1.5 text-xs font-medium text-fg-muted">Download as</legend>
+      <div className="flex flex-wrap items-center gap-2">
+        {RESPONSE_FORMATS.map((format) => {
+          const p = plan(format);
+          return (
+            <Button
+              key={format}
+              variant="secondary"
+              disabled={busy !== null || p.kind === "unavailable"}
+              title={p.kind === "unavailable" ? p.reason : `Download ${format}`}
+              onClick={() => void doExport(format)}
+            >
+              {busy === format ? <Spinner /> : <DownloadIcon />}
+              {format}
+            </Button>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}

--- a/webui/src/components/FileDrop.tsx
+++ b/webui/src/components/FileDrop.tsx
@@ -1,0 +1,107 @@
+import { useRef, useState } from "react";
+
+import { validateFile } from "../lib/files";
+import { fmtBytes } from "../lib/format";
+import { buttonSecondaryClass } from "./ui";
+
+export function FileDrop(props: {
+  file: File | null;
+  onSelect: (file: File | null) => void;
+  disabled?: boolean;
+  maxUploadBytes?: number | null;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [dragging, setDragging] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [warning, setWarning] = useState<string | null>(null);
+
+  const takeFile = (file: File | undefined) => {
+    if (!file) return;
+    const verdict = validateFile(file, props.maxUploadBytes ?? null);
+    if (!verdict.ok) {
+      setError(verdict.reason);
+      setWarning(null);
+      props.onSelect(null);
+      return;
+    }
+    setError(null);
+    setWarning(verdict.warning);
+    props.onSelect(file);
+  };
+
+  return (
+    <div>
+      <button
+        type="button"
+        disabled={props.disabled}
+        onDragOver={(e) => {
+          e.preventDefault();
+          if (!props.disabled) setDragging(true);
+        }}
+        onDragLeave={() => setDragging(false)}
+        onDrop={(e) => {
+          e.preventDefault();
+          setDragging(false);
+          if (!props.disabled) takeFile(e.dataTransfer.files?.[0]);
+        }}
+        onClick={() => inputRef.current?.click()}
+        className={`flex min-h-40 w-full cursor-pointer flex-col items-center justify-center gap-3 rounded-sm border-2 border-dashed p-6 text-center transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-focus ${
+          dragging
+            ? "border-accent bg-accent-subtle"
+            : "border-border-strong bg-surface hover:border-accent-text"
+        } ${props.disabled ? "cursor-not-allowed opacity-60" : ""}`}
+      >
+        <svg
+          aria-hidden="true"
+          viewBox="0 0 24 24"
+          className="h-8 w-8 text-fg-subtle"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M12 16.5V4m0 0L7.5 8.5M12 4l4.5 4.5M4 19.5h16"
+          />
+        </svg>
+        {props.file ? (
+          <span className="text-sm">
+            <span className="block font-medium text-fg">{props.file.name}</span>
+            <span className="block tabular-nums text-fg-muted">
+              {fmtBytes(props.file.size)}
+            </span>
+          </span>
+        ) : (
+          <span className="text-sm text-fg-muted">
+            drop audio / video here — or click to browse
+          </span>
+        )}
+        <span
+          aria-hidden="true"
+          className={`${buttonSecondaryClass} pointer-events-none`}
+        >
+          {props.file ? "Choose a different file" : "Browse files"}
+        </span>
+      </button>
+      <input
+        ref={inputRef}
+        type="file"
+        accept="audio/*,video/*"
+        className="sr-only"
+        aria-hidden="true"
+        tabIndex={-1}
+        onChange={(e) => {
+          takeFile(e.target.files?.[0]);
+          e.target.value = "";
+        }}
+      />
+      {error ? (
+        <p role="alert" className="mt-2 text-sm text-danger-text">
+          {error}
+        </p>
+      ) : null}
+      {warning ? <p className="mt-2 text-sm text-warn-text">{warning}</p> : null}
+    </div>
+  );
+}

--- a/webui/src/components/OptionsPanel.test.tsx
+++ b/webui/src/components/OptionsPanel.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { DEFAULT_OPTIONS, normalizeOptions } from "../lib/options";
+import { OptionsPanel } from "./OptionsPanel";
+
+const renderPanel = (
+  optionsPatch: Partial<typeof DEFAULT_OPTIONS>,
+  onChange = vi.fn(),
+) => {
+  render(
+    <OptionsPanel
+      options={normalizeOptions({ ...DEFAULT_OPTIONS, ...optionsPatch })}
+      onChange={onChange}
+      modelSuggestions={[]}
+    />,
+  );
+  return onChange;
+};
+
+describe("OptionsPanel", () => {
+  it("disables diarization and speaker embeddings until alignment is on", () => {
+    renderPanel({ align: false });
+    expect(screen.getByLabelText(/Diarize speakers/)).toBeDisabled();
+    expect(screen.getByLabelText(/Speaker embeddings/)).toBeDisabled();
+  });
+
+  it("enables diarization with alignment, and embeddings once diarizing", () => {
+    renderPanel({ align: true, diarize: true });
+    expect(screen.getByLabelText(/Diarize speakers/)).toBeEnabled();
+    expect(screen.getByLabelText(/Speaker embeddings/)).toBeEnabled();
+  });
+
+  it("cascades the invariants through onChange when alignment is turned off", async () => {
+    const onChange = renderPanel({ align: true, diarize: true });
+    await userEvent.click(screen.getByLabelText(/Align timestamps/));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ align: false, diarize: false }),
+    );
+  });
+});

--- a/webui/src/components/OptionsPanel.tsx
+++ b/webui/src/components/OptionsPanel.tsx
@@ -1,0 +1,207 @@
+import { LANGUAGES } from "../lib/languages";
+import { normalizeOptions, type TranscriptionOptions } from "../lib/options";
+import { Field, inputClass, Toggle } from "./ui";
+
+const SUGGESTED_MODELS = [
+  "large-v3",
+  "large-v3-turbo",
+  "large-v2",
+  "distil-large-v3",
+  "medium",
+  "small",
+  "base",
+  "tiny",
+];
+
+export function OptionsPanel(props: {
+  options: TranscriptionOptions;
+  onChange: (options: TranscriptionOptions) => void;
+  modelSuggestions: string[];
+  disabled?: boolean;
+}) {
+  const { options, disabled } = props;
+  const set = (patch: Partial<TranscriptionOptions>) =>
+    props.onChange(normalizeOptions({ ...options, ...patch }));
+
+  const suggestions = [...new Set([...props.modelSuggestions, ...SUGGESTED_MODELS])];
+
+  return (
+    <fieldset disabled={disabled} className="flex flex-col gap-4">
+      <legend className="sr-only">Transcription options</legend>
+
+      <Field id="opt-model" label="Model" hint="Empty = server default.">
+        <input
+          id="opt-model"
+          list="opt-model-suggestions"
+          className={inputClass}
+          value={options.model}
+          placeholder="server default"
+          onChange={(e) => set({ model: e.target.value })}
+        />
+        <datalist id="opt-model-suggestions">
+          {suggestions.map((m) => (
+            <option key={m} value={m} />
+          ))}
+        </datalist>
+      </Field>
+
+      <Field id="opt-language" label="Language">
+        <select
+          id="opt-language"
+          className={inputClass}
+          value={options.language}
+          onChange={(e) => set({ language: e.target.value })}
+        >
+          <option value="">Auto-detect</option>
+          {LANGUAGES.map((l) => (
+            <option key={l.code} value={l.code}>
+              {l.label} ({l.code})
+            </option>
+          ))}
+        </select>
+      </Field>
+
+      <div className="flex flex-col gap-2.5 rounded-lg border border-border bg-surface-2 p-3">
+        <p className="text-xs font-semibold uppercase tracking-wide text-fg-muted">
+          Pipeline
+        </p>
+        <Toggle
+          id="opt-align"
+          label="Align timestamps"
+          hint="Word-level timing; required for subtitles and diarization."
+          checked={options.align}
+          onChange={(v) => set({ align: v })}
+        />
+        <Toggle
+          id="opt-diarize"
+          label="Diarize speakers"
+          hint={options.align ? undefined : "Requires alignment."}
+          checked={options.diarize}
+          disabled={!options.align}
+          onChange={(v) => set({ diarize: v })}
+        />
+        <Toggle
+          id="opt-speaker-embeddings"
+          label="Speaker embeddings"
+          hint={
+            options.diarize
+              ? "Adds per-speaker voiceprint vectors to the downloaded JSON (for speaker identification). No change to the on-screen transcript."
+              : "Requires diarization."
+          }
+          checked={options.speakerEmbeddings}
+          disabled={!options.diarize}
+          onChange={(v) => set({ speakerEmbeddings: v })}
+        />
+        {options.diarize ? (
+          <div className="grid grid-cols-2 gap-3">
+            <Field id="opt-min-speakers" label="Min speakers" hint="Optional.">
+              <input
+                id="opt-min-speakers"
+                type="number"
+                min="1"
+                className={inputClass}
+                value={options.minSpeakers}
+                placeholder="auto"
+                onChange={(e) => set({ minSpeakers: e.target.value })}
+              />
+            </Field>
+            <Field id="opt-max-speakers" label="Max speakers" hint="Optional.">
+              <input
+                id="opt-max-speakers"
+                type="number"
+                min="1"
+                className={inputClass}
+                value={options.maxSpeakers}
+                placeholder="auto"
+                onChange={(e) => set({ maxSpeakers: e.target.value })}
+              />
+            </Field>
+          </div>
+        ) : null}
+      </div>
+
+      <details className="rounded-lg border border-border">
+        <summary className="cursor-pointer select-none px-3 py-2 text-sm font-medium text-fg-muted hover:bg-surface-2">
+          Advanced
+        </summary>
+        <div className="flex flex-col gap-4 border-t border-border p-3">
+          <Field id="opt-temperature" label="Temperature">
+            <input
+              id="opt-temperature"
+              type="number"
+              min="0"
+              max="1"
+              step="0.1"
+              className={inputClass}
+              value={options.temperature}
+              onChange={(e) => set({ temperature: e.target.value })}
+            />
+          </Field>
+          <Field
+            id="opt-prompt"
+            label="Prompt"
+            hint="Optional context hint for the decoder."
+          >
+            <textarea
+              id="opt-prompt"
+              rows={2}
+              className={inputClass}
+              value={options.prompt}
+              onChange={(e) => set({ prompt: e.target.value })}
+            />
+          </Field>
+          <Field
+            id="opt-hotwords"
+            label="Hotwords"
+            hint="Comma-separated terms to bias toward."
+          >
+            <input
+              id="opt-hotwords"
+              className={inputClass}
+              value={options.hotwords}
+              onChange={(e) => set({ hotwords: e.target.value })}
+            />
+          </Field>
+          <div className="grid grid-cols-2 gap-3">
+            <Field id="opt-batch" label="Batch size" hint="Empty = default.">
+              <input
+                id="opt-batch"
+                type="number"
+                min="1"
+                className={inputClass}
+                value={options.batchSize}
+                placeholder="default"
+                onChange={(e) => set({ batchSize: e.target.value })}
+              />
+            </Field>
+            <Field id="opt-chunk" label="Chunk size (s)" hint="Empty = default.">
+              <input
+                id="opt-chunk"
+                type="number"
+                min="1"
+                className={inputClass}
+                value={options.chunkSize}
+                placeholder="default"
+                onChange={(e) => set({ chunkSize: e.target.value })}
+              />
+            </Field>
+          </div>
+          <Toggle
+            id="opt-suppress-numerals"
+            label="Suppress numerals"
+            hint="Spell out numbers instead of digits."
+            checked={options.suppressNumerals}
+            onChange={(v) => set({ suppressNumerals: v })}
+          />
+          <Toggle
+            id="opt-highlight-words"
+            label="Highlight words in subtitles"
+            hint="Affects vtt / srt output only."
+            checked={options.highlightWords}
+            onChange={(v) => set({ highlightWords: v })}
+          />
+        </div>
+      </details>
+    </fieldset>
+  );
+}

--- a/webui/src/components/ResultView.tsx
+++ b/webui/src/components/ResultView.tsx
@@ -1,0 +1,307 @@
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import type { Segment, VerbosePayload, WordTiming } from "../api/types";
+import { useAudioSync } from "../hooks/useAudioSync";
+import { fmtClock, fmtDuration, speakerColor } from "../lib/format";
+import type { TranscriptionOptions } from "../lib/options";
+import { hasWordTimings, normalizeResult } from "../lib/result";
+import { ExportBar } from "./ExportBar";
+import { Button, Toggle } from "./ui";
+
+const prefersReducedMotion = () =>
+  window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+
+const WordSpan = memo(function WordSpan(props: {
+  word: WordTiming;
+  active: boolean;
+  seekable: boolean;
+  onSeek: (t: number) => void;
+}) {
+  const { word } = props;
+  const start = word.start;
+  const text = word.word;
+  const cls = props.active
+    ? "rounded-sm bg-accent text-on-accent"
+    : start !== undefined && props.seekable
+      ? "rounded-sm hover:bg-accent-subtle"
+      : "";
+
+  if (start === undefined || !props.seekable) {
+    return <span className={cls}>{text} </span>;
+  }
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => props.onSeek(start)}
+        className={`${cls} focus:outline-none focus-visible:ring-1 focus-visible:ring-focus`}
+      >
+        {text}
+      </button>{" "}
+    </>
+  );
+});
+
+const SegmentRow = memo(function SegmentRow(props: {
+  segment: Segment;
+  index: number;
+  isActive: boolean;
+  activeWord: number;
+  wordLevel: boolean;
+  playable: boolean;
+  speakerBg: string | undefined;
+  onSeek: (t: number) => void;
+}) {
+  const { segment, isActive, playable } = props;
+  const words = segment.words ?? [];
+  return (
+    <li
+      data-segment={props.index}
+      className={`segment-row group flex gap-3 border-b border-border px-4 py-2.5 last:border-b-0 ${
+        isActive ? "bg-accent-subtle" : ""
+      }`}
+    >
+      <div className="w-24 shrink-0 pt-0.5 text-right">
+        <button
+          type="button"
+          disabled={!playable}
+          onClick={() => props.onSeek(segment.start)}
+          title={playable ? "Jump to this segment" : undefined}
+          className="text-xs tabular-nums text-fg-subtle hover:text-accent-text focus:outline-none focus-visible:ring-1 focus-visible:ring-focus disabled:hover:text-fg-subtle"
+        >
+          [{fmtClock(segment.start)}]
+        </button>
+        {segment.speaker ? (
+          <span
+            className="mt-1 block truncate rounded px-1 py-0.5 text-[10px] font-medium text-white"
+            style={{ backgroundColor: props.speakerBg }}
+            title={segment.speaker}
+          >
+            {segment.speaker}
+          </span>
+        ) : null}
+      </div>
+      <p className="min-w-0 flex-1 font-sans text-sm leading-relaxed text-fg">
+        {props.wordLevel && words.length > 0 ? (
+          words.map((w, wi) => (
+            <WordSpan
+              key={`${w.start}-${w.end}-${w.word}`}
+              word={w}
+              active={isActive && wi === props.activeWord}
+              seekable={playable}
+              onSeek={props.onSeek}
+            />
+          ))
+        ) : playable ? (
+          <button
+            type="button"
+            onClick={() => props.onSeek(segment.start)}
+            className="text-left hover:text-accent-text focus:outline-none focus-visible:ring-1 focus-visible:ring-focus"
+          >
+            {segment.text.trim()}
+          </button>
+        ) : (
+          segment.text.trim()
+        )}
+      </p>
+    </li>
+  );
+});
+
+export function ResultView(props: {
+  payload: VerbosePayload;
+  file: File;
+  options: TranscriptionOptions;
+  requestId: string;
+  subtitleAvailable: boolean;
+  apiKey: string | null;
+  durationSeconds: number | null;
+  optionsChanged: boolean;
+  onRerun: () => void;
+  onReset: () => void;
+}) {
+  const normalized = useMemo(() => normalizeResult(props.payload), [props.payload]);
+  const { segments, speakers } = normalized;
+  const wordLevel = useMemo(() => hasWordTimings(segments), [segments]);
+
+  const speakerIndex = useMemo(() => new Map(speakers.map((s, i) => [s, i])), [speakers]);
+
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const headingRef = useRef<HTMLHeadingElement>(null);
+  const [playable, setPlayable] = useState(true);
+  const [follow, setFollow] = useState(true);
+  const [copied, setCopied] = useState(false);
+
+  const { active, playing } = useAudioSync(audioRef, segments, wordLevel, playable);
+
+  const objectUrl = useMemo(() => URL.createObjectURL(props.file), [props.file]);
+  useEffect(() => () => URL.revokeObjectURL(objectUrl), [objectUrl]);
+
+  // Move focus to the result heading when it appears so keyboard / screen-reader
+  // users are taken to the new content.
+  useEffect(() => {
+    headingRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    if (!follow || !playing || active.segment < 0) return;
+    listRef.current?.querySelector(`[data-segment="${active.segment}"]`)?.scrollIntoView({
+      block: "nearest",
+      behavior: prefersReducedMotion() ? "auto" : "smooth",
+    });
+  }, [active.segment, follow, playing]);
+
+  const seek = useCallback(
+    (t: number) => {
+      const audio = audioRef.current;
+      if (!audio || !playable) return;
+      audio.currentTime = t;
+      void audio.play();
+    },
+    [playable],
+  );
+
+  const copyText = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(normalized.text);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard unavailable (insecure context) */
+    }
+  }, [normalized.text]);
+
+  return (
+    <section aria-label="Transcription result" className="flex flex-col gap-4">
+      <div className="rounded-sm border border-border bg-surface p-5">
+        <div className="mb-3 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+          <h2
+            ref={headingRef}
+            tabIndex={-1}
+            className="text-base font-semibold text-fg focus:outline-none"
+          >
+            {props.file.name}
+          </h2>
+          <p className="text-xs text-fg-muted">
+            {segments.length} segment{segments.length === 1 ? "" : "s"}
+            {normalized.language ? ` · language: ${normalized.language}` : ""}
+            {wordLevel ? " · word timings" : ""}
+            {props.durationSeconds !== null
+              ? ` · done in ${fmtDuration(props.durationSeconds)}`
+              : ""}
+          </p>
+          <div className="ml-auto flex flex-wrap items-center gap-2">
+            {props.optionsChanged ? (
+              <span className="text-[11px] font-medium text-accent-text">
+                options changed
+              </span>
+            ) : null}
+            <Button
+              variant={props.optionsChanged ? "primary" : "secondary"}
+              onClick={props.onRerun}
+              title="Re-transcribe this same file with the current options — no re-upload needed"
+            >
+              Re-run
+            </Button>
+            <Button variant="secondary" onClick={props.onReset}>
+              New file
+            </Button>
+          </div>
+        </div>
+
+        <ExportBar
+          payload={props.payload}
+          requestId={props.requestId}
+          file={props.file}
+          options={props.options}
+          subtitleAvailable={props.subtitleAvailable}
+          apiKey={props.apiKey}
+        />
+
+        {speakers.length > 0 ? (
+          <ul aria-label="Speakers" className="mt-3 flex flex-wrap gap-2">
+            {speakers.map((s, i) => (
+              <li
+                key={s}
+                className="rounded-sm px-2.5 py-0.5 text-xs font-medium text-white"
+                style={{ backgroundColor: speakerColor(i) }}
+              >
+                {s}
+              </li>
+            ))}
+          </ul>
+        ) : null}
+
+        <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
+          {playable ? (
+            // biome-ignore lint/a11y/useMediaCaption: user-supplied audio has no caption track
+            <audio
+              ref={audioRef}
+              controls
+              src={objectUrl}
+              onError={() => setPlayable(false)}
+              className="h-11 w-full sm:h-10 sm:w-auto sm:min-w-0 sm:flex-1"
+            />
+          ) : (
+            <p className="text-xs text-fg-muted">
+              This browser can’t play the source file — click-to-seek is disabled.
+            </p>
+          )}
+          <div className="flex items-center gap-3">
+            {playable ? (
+              <Toggle
+                id="follow-playback"
+                label="Follow playback"
+                checked={follow}
+                onChange={setFollow}
+              />
+            ) : null}
+            <Button variant="secondary" onClick={() => void copyText()}>
+              {copied ? "Copied!" : "Copy text"}
+            </Button>
+            <span role="status" aria-live="polite" className="sr-only">
+              {copied ? "Transcript copied to clipboard" : ""}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div
+        ref={listRef}
+        className="term-scroll max-h-[60vh] overflow-y-auto rounded-sm border border-border bg-surface"
+      >
+        {segments.length === 0 ? (
+          <p className="p-5 text-sm text-fg-muted">
+            The result contains no segments
+            {normalized.text ? " — raw text below:" : "."}
+            {normalized.text ? (
+              <span className="mt-2 block whitespace-pre-wrap text-fg">
+                {normalized.text}
+              </span>
+            ) : null}
+          </p>
+        ) : (
+          <ol>
+            {segments.map((seg, i) => {
+              const spkIdx = seg.speaker ? speakerIndex.get(seg.speaker) : undefined;
+              return (
+                <SegmentRow
+                  key={`${seg.start}-${seg.end}`}
+                  segment={seg}
+                  index={i}
+                  isActive={i === active.segment}
+                  activeWord={i === active.segment ? active.word : -1}
+                  wordLevel={wordLevel}
+                  playable={playable}
+                  speakerBg={seg.speaker ? speakerColor(spkIdx ?? 0) : undefined}
+                  onSeek={seek}
+                />
+              );
+            })}
+          </ol>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/webui/src/components/StagesPanel.tsx
+++ b/webui/src/components/StagesPanel.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useState } from "react";
+
+import type { RequestStatus } from "../api/types";
+import type { JobPhase } from "../hooks/useTranscriptionJob";
+import { fmtDuration, prettyStageName } from "../lib/format";
+import { Button, CopyButton } from "./ui";
+
+function UploadBar(props: { fraction: number | null }) {
+  const pct = props.fraction !== null ? Math.round(props.fraction * 100) : null;
+  return (
+    <div>
+      <div className="mb-1 flex justify-between text-xs text-fg-muted">
+        <span>uploading</span>
+        <span className="tabular-nums">{pct !== null ? `${pct}%` : "…"}</span>
+      </div>
+      <div
+        role="progressbar"
+        aria-label="Upload progress"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={pct ?? undefined}
+        className="h-2 overflow-hidden rounded-sm bg-fill"
+      >
+        <div
+          className={`h-full bg-accent transition-[width] duration-300 ${
+            pct === null ? "w-1/3 animate-pulse" : ""
+          }`}
+          style={pct !== null ? { width: `${pct}%` } : undefined}
+        />
+      </div>
+    </div>
+  );
+}
+
+function StageRow(props: {
+  name: string;
+  inProgress: boolean;
+  duration: number | undefined;
+}) {
+  const { label, worker } = prettyStageName(props.name);
+  return (
+    <li className="flex items-center gap-2.5 py-1.5 text-sm">
+      <span
+        aria-hidden="true"
+        className={`tabular-nums ${props.inProgress ? "text-accent-text" : "text-success"}`}
+      >
+        {props.inProgress ? "[··]" : "[ok]"}
+      </span>
+      <span className="text-fg-muted">{label}</span>
+      {worker ? (
+        <span className="rounded-sm bg-fill px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-fg-muted">
+          worker
+        </span>
+      ) : null}
+      <span className="ml-auto text-xs tabular-nums text-fg-subtle">
+        {props.inProgress
+          ? "running"
+          : props.duration !== undefined
+            ? fmtDuration(props.duration)
+            : ""}
+      </span>
+    </li>
+  );
+}
+
+function useElapsed(since: number | null): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const t = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(t);
+  }, []);
+  return since === null ? 0 : Math.max(0, (now - since) / 1000);
+}
+
+export function StagesPanel(props: {
+  phase: JobPhase;
+  status: RequestStatus | null;
+  uploadProgress: number | null;
+  requestId: string | null;
+  fileName: string | null;
+  startedAtMs: number | null;
+  onCancel: () => void;
+}) {
+  const { phase, status } = props;
+  const elapsed = useElapsed(props.startedAtMs);
+  const running = phase === "uploading" || phase === "processing";
+
+  const phaseLabel =
+    phase === "uploading"
+      ? "uploading"
+      : status?.status === "queued"
+        ? "queued"
+        : "processing";
+
+  return (
+    <section
+      aria-label="Job progress"
+      className="rounded-sm border border-border bg-surface p-5"
+    >
+      <div className="mb-4 flex flex-wrap items-center gap-3">
+        <span className="relative flex h-2.5 w-2.5" aria-hidden="true">
+          <span className="absolute inline-flex h-full w-full animate-ping bg-accent opacity-75" />
+          <span className="relative inline-flex h-2.5 w-2.5 bg-accent" />
+        </span>
+        <p aria-live="polite" className="text-sm font-semibold text-fg">
+          {phaseLabel}
+          {props.fileName ? (
+            <span className="font-normal text-fg-muted"> — {props.fileName}</span>
+          ) : null}
+        </p>
+        <span className="ml-auto text-xs tabular-nums text-fg-subtle">
+          {fmtDuration(elapsed)}
+        </span>
+        {running ? (
+          <Button variant="secondary" onClick={props.onCancel}>
+            Cancel
+          </Button>
+        ) : null}
+      </div>
+
+      {phase === "uploading" ? (
+        <div className="mb-4">
+          <UploadBar fraction={props.uploadProgress} />
+        </div>
+      ) : null}
+
+      {status && status.stages.length > 0 ? (
+        <ol className="divide-y divide-border">
+          {status.stages.map((s) => (
+            <StageRow
+              key={s.name}
+              name={s.name}
+              inProgress={Boolean(s.in_progress)}
+              duration={s.duration_seconds}
+            />
+          ))}
+        </ol>
+      ) : (
+        <p className="text-sm text-fg-muted">
+          {phase === "uploading"
+            ? "the server registers the request once the upload completes."
+            : "waiting for the first stage report…"}
+        </p>
+      )}
+
+      {props.requestId ? (
+        <p className="mt-4 flex items-center gap-1.5 border-t border-border pt-3 text-[11px] text-fg-subtle">
+          request id: <code>{props.requestId}</code>
+          <CopyButton value={props.requestId} />
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/webui/src/components/ThemeToggle.tsx
+++ b/webui/src/components/ThemeToggle.tsx
@@ -1,0 +1,53 @@
+import { useTheme } from "../hooks/useTheme";
+
+function SunIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      className="h-5 w-5"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4" />
+    </svg>
+  );
+}
+
+function MoonIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      className="h-5 w-5"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8Z" />
+    </svg>
+  );
+}
+
+export function ThemeToggle() {
+  const { theme, toggle } = useTheme();
+  const dark = theme === "dark";
+  const label = dark ? "Switch to light theme" : "Switch to dark theme";
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label={label}
+      title={label}
+      className="rounded-sm p-1.5 text-fg-muted hover:bg-surface-2 hover:text-fg focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
+    >
+      {dark ? <SunIcon /> : <MoonIcon />}
+    </button>
+  );
+}

--- a/webui/src/components/Toast.tsx
+++ b/webui/src/components/Toast.tsx
@@ -1,0 +1,74 @@
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+type ToastKind = "success" | "error" | "info";
+
+interface ToastItem {
+  id: number;
+  message: string;
+  kind: ToastKind;
+}
+
+interface ToastApi {
+  toast: (message: string, kind?: ToastKind) => void;
+}
+
+const ToastContext = createContext<ToastApi | null>(null);
+
+export function useToasts(): ToastApi {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error("useToasts must be used within <ToastProvider>");
+  return ctx;
+}
+
+function toastClass(kind: ToastKind): string {
+  if (kind === "error") return "border-danger-border bg-danger-bg text-danger-strong";
+  return "border-border bg-surface text-fg";
+}
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+  const idRef = useRef(0);
+
+  const toast = useCallback((message: string, kind: ToastKind = "info") => {
+    const id = ++idRef.current;
+    setToasts((prev) => [...prev, { id, message, kind }]);
+    window.setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== id));
+    }, 4000);
+  }, []);
+
+  const api = useMemo(() => ({ toast }), [toast]);
+
+  return (
+    <ToastContext.Provider value={api}>
+      {children}
+      <div
+        className="pointer-events-none fixed inset-x-0 bottom-4 z-50 flex flex-col items-center gap-2 px-4"
+        aria-live="polite"
+      >
+        {toasts.map((t) => (
+          <div
+            key={t.id}
+            role={t.kind === "error" ? "alert" : "status"}
+            className={`pointer-events-auto max-w-sm rounded-sm border px-4 py-2 text-sm ${toastClass(
+              t.kind,
+            )}`}
+          >
+            <span aria-hidden="true" className="opacity-60">
+              {"> "}
+            </span>
+            {t.message}
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}

--- a/webui/src/components/ui.tsx
+++ b/webui/src/components/ui.tsx
@@ -1,0 +1,124 @@
+import { type ButtonHTMLAttributes, type ReactNode, useState } from "react";
+
+export function Field(props: {
+  id: string;
+  label: string;
+  hint?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label htmlFor={props.id} className="text-xs font-medium text-fg-muted">
+        {props.label}
+      </label>
+      {props.children}
+      {props.hint ? <p className="text-[11px] text-fg-subtle">{props.hint}</p> : null}
+    </div>
+  );
+}
+
+export function Toggle(props: {
+  id: string;
+  label: string;
+  checked: boolean;
+  onChange: (value: boolean) => void;
+  disabled?: boolean;
+  hint?: string;
+}) {
+  return (
+    <div className="flex items-start gap-2">
+      <input
+        id={props.id}
+        type="checkbox"
+        checked={props.checked}
+        disabled={props.disabled}
+        onChange={(e) => props.onChange(e.target.checked)}
+        className="mt-0.5 h-4 w-4 rounded-none border-border-strong accent-[var(--color-accent)] disabled:opacity-40"
+      />
+      <label
+        htmlFor={props.id}
+        className={`text-sm ${props.disabled ? "text-fg-subtle" : "text-fg-muted"}`}
+      >
+        {props.label}
+        {props.hint ? (
+          <span className="block text-[11px] text-fg-subtle">{props.hint}</span>
+        ) : null}
+      </label>
+    </div>
+  );
+}
+
+export const inputClass =
+  "w-full rounded-sm border border-border-strong bg-surface px-2.5 py-1.5 text-sm text-fg " +
+  "placeholder:text-fg-subtle focus:outline-none focus-visible:ring-2 focus-visible:ring-focus " +
+  "disabled:bg-surface-2 disabled:text-fg-subtle";
+
+export const buttonPrimaryClass =
+  "inline-flex items-center justify-center gap-2 rounded-sm bg-accent px-4 py-2 text-sm font-semibold " +
+  "text-on-accent hover:bg-accent-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-focus " +
+  "focus-visible:ring-offset-2 ring-offset-surface " +
+  "disabled:cursor-not-allowed disabled:bg-fill disabled:text-fg-subtle";
+
+export const buttonSecondaryClass =
+  "inline-flex items-center justify-center gap-1.5 rounded-sm border border-border-strong bg-surface-2 px-3 py-1.5 " +
+  "text-sm font-medium text-fg-muted hover:bg-fill hover:text-fg focus:outline-none focus-visible:ring-2 " +
+  "focus-visible:ring-focus disabled:cursor-not-allowed disabled:opacity-50";
+
+/**
+ * Single source of truth for buttons. Wraps the shared class strings so call sites
+ * pick a `variant` instead of repeating them; extra `className` is appended.
+ */
+export function Button({
+  variant = "primary",
+  className,
+  type,
+  ...rest
+}: ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: "primary" | "secondary";
+}) {
+  const base = variant === "primary" ? buttonPrimaryClass : buttonSecondaryClass;
+  return (
+    <button
+      type={type ?? "button"}
+      className={className ? `${base} ${className}` : base}
+      {...rest}
+    />
+  );
+}
+
+export function Spinner(props: { className?: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={`inline-block h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent ${props.className ?? ""}`}
+    />
+  );
+}
+
+export function CopyButton(props: { value: string; label?: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => {
+          void navigator.clipboard
+            .writeText(props.value)
+            .then(() => {
+              setCopied(true);
+              window.setTimeout(() => setCopied(false), 1200);
+            })
+            .catch(() => {
+              /* clipboard unavailable (insecure context) */
+            });
+        }}
+        className="rounded-sm px-1 text-fg-subtle hover:text-fg focus:outline-none focus-visible:ring-1 focus-visible:ring-focus"
+      >
+        {copied ? "copied" : (props.label ?? "copy")}
+      </button>
+      <span role="status" aria-live="polite" className="sr-only">
+        {copied ? "Copied to clipboard" : ""}
+      </span>
+    </>
+  );
+}

--- a/webui/src/hooks/useAudioSync.ts
+++ b/webui/src/hooks/useAudioSync.ts
@@ -1,0 +1,94 @@
+import { type RefObject, useEffect, useState } from "react";
+
+import type { Segment } from "../api/types";
+
+export interface ActivePosition {
+  segment: number;
+  word: number;
+}
+
+function findActive(
+  segments: Segment[],
+  time: number,
+  wordLevel: boolean,
+): ActivePosition {
+  let active = -1;
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i];
+    if (time >= seg.start && time < seg.end) {
+      active = i;
+      break;
+    }
+    if (seg.start > time) break;
+    active = i; // between segments: stick to the last one started
+  }
+  if (active === -1 || !wordLevel) return { segment: active, word: -1 };
+
+  const words = segments[active].words ?? [];
+  let activeWord = -1;
+  for (let i = 0; i < words.length; i++) {
+    const w = words[i];
+    if (w.start === undefined) continue;
+    if (time >= w.start && (w.end === undefined || time < w.end)) {
+      activeWord = i;
+      break;
+    }
+    if (w.start > time) break;
+    activeWord = i;
+  }
+  return { segment: active, word: activeWord };
+}
+
+/**
+ * Tracks the segment/word under the audio playhead. Word-level highlighting needs
+ * finer granularity than the ~4 Hz `timeupdate` event, so playback is followed with
+ * rAF while playing. State only updates when the active position actually changes.
+ */
+export function useAudioSync(
+  audioRef: RefObject<HTMLAudioElement | null>,
+  segments: Segment[],
+  wordLevel: boolean,
+  enabled: boolean,
+): { active: ActivePosition; playing: boolean } {
+  const [active, setActive] = useState<ActivePosition>({ segment: -1, word: -1 });
+  const [playing, setPlaying] = useState(false);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio || !enabled) return;
+
+    let raf = 0;
+    const sync = () => {
+      const pos = findActive(segments, audio.currentTime, wordLevel);
+      setActive((prev) =>
+        prev.segment === pos.segment && prev.word === pos.word ? prev : pos,
+      );
+    };
+    const loop = () => {
+      sync();
+      raf = requestAnimationFrame(loop);
+    };
+    const onPlay = () => {
+      setPlaying(true);
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(loop);
+    };
+    const onPause = () => {
+      setPlaying(false);
+      cancelAnimationFrame(raf);
+      sync();
+    };
+
+    audio.addEventListener("play", onPlay);
+    audio.addEventListener("pause", onPause);
+    audio.addEventListener("seeked", sync);
+    return () => {
+      cancelAnimationFrame(raf);
+      audio.removeEventListener("play", onPlay);
+      audio.removeEventListener("pause", onPause);
+      audio.removeEventListener("seeked", sync);
+    };
+  }, [audioRef, segments, wordLevel, enabled]);
+
+  return { active, playing };
+}

--- a/webui/src/hooks/useServerConnection.ts
+++ b/webui/src/hooks/useServerConnection.ts
@@ -1,0 +1,121 @@
+/**
+ * Reachability + auth handshake. GET /info doubles as the auth probe: it sits
+ * behind the same key dependency as the rest of the API, so an unauthenticated
+ * 200 means no key is configured (the key field is then hidden), while 401/403
+ * means a key is required.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { getInfo } from "../api/client";
+import type { ServerInfo } from "../api/types";
+
+const STORAGE_KEY = "whisperx-webui-api-key";
+
+export type ConnectionPhase = "connecting" | "unreachable" | "need-key" | "ready";
+
+export interface ServerConnection {
+  phase: ConnectionPhase;
+  authRequired: boolean;
+  info: ServerInfo | null;
+  apiKey: string | null;
+  keyError: string | null;
+  submitKey: (key: string, remember: boolean) => Promise<void>;
+  clearKey: () => void;
+  retry: () => void;
+}
+
+export function useServerConnection(): ServerConnection {
+  const [phase, setPhase] = useState<ConnectionPhase>("connecting");
+  const [authRequired, setAuthRequired] = useState(false);
+  const [info, setInfo] = useState<ServerInfo | null>(null);
+  const [apiKey, setApiKey] = useState<string | null>(null);
+  const [keyError, setKeyError] = useState<string | null>(null);
+  const aliveRef = useRef(true);
+
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => {
+      aliveRef.current = false;
+    };
+  }, []);
+
+  const connect = useCallback(async () => {
+    setPhase("connecting");
+    setKeyError(null);
+
+    const anonymous = await getInfo(null);
+    if (!aliveRef.current) return;
+
+    if (anonymous.ok) {
+      setAuthRequired(false);
+      setApiKey(null);
+      setInfo(anonymous.info);
+      setPhase("ready");
+      return;
+    }
+    if (anonymous.status === null) {
+      setPhase("unreachable");
+      return;
+    }
+    if (anonymous.status !== 401 && anonymous.status !== 403) {
+      // /info failing with an unexpected status: treat as unreachable.
+      setPhase("unreachable");
+      return;
+    }
+
+    setAuthRequired(true);
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      const withKey = await getInfo(stored);
+      if (!aliveRef.current) return;
+      if (withKey.ok) {
+        setApiKey(stored);
+        setInfo(withKey.info);
+        setPhase("ready");
+        return;
+      }
+      localStorage.removeItem(STORAGE_KEY);
+    }
+    setPhase("need-key");
+  }, []);
+
+  useEffect(() => {
+    void connect();
+  }, [connect]);
+
+  const submitKey = useCallback(async (key: string, remember: boolean) => {
+    setKeyError(null);
+    const result = await getInfo(key);
+    if (!aliveRef.current) return;
+    if (result.ok) {
+      setApiKey(key);
+      setInfo(result.info);
+      setPhase("ready");
+      if (remember) localStorage.setItem(STORAGE_KEY, key);
+      return;
+    }
+    setKeyError(
+      result.status === 401 || result.status === 403
+        ? "Invalid API key."
+        : "Could not verify the key — server unreachable.",
+    );
+  }, []);
+
+  const clearKey = useCallback(() => {
+    localStorage.removeItem(STORAGE_KEY);
+    setApiKey(null);
+    setPhase("need-key");
+  }, []);
+
+  return {
+    phase,
+    authRequired,
+    info,
+    apiKey,
+    keyError,
+    submitKey,
+    clearKey,
+    retry: () => void connect(),
+  };
+}

--- a/webui/src/hooks/useStoredOptions.ts
+++ b/webui/src/hooks/useStoredOptions.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+
+import {
+  DEFAULT_OPTIONS,
+  normalizeOptions,
+  type TranscriptionOptions,
+} from "../lib/options";
+
+const STORAGE_KEY = "whisperx-webui-options";
+
+function load(): TranscriptionOptions {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULT_OPTIONS;
+    const parsed = JSON.parse(raw) as Partial<TranscriptionOptions>;
+    // Merge onto defaults so a stored blob from an older version still gets any
+    // newly-added fields, then re-apply the server invariants.
+    return normalizeOptions({ ...DEFAULT_OPTIONS, ...parsed });
+  } catch {
+    return DEFAULT_OPTIONS;
+  }
+}
+
+/** Transcription options that persist across reloads (localStorage-backed). */
+export function useStoredOptions() {
+  const state = useState<TranscriptionOptions>(load);
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(state[0]));
+    } catch {
+      /* storage unavailable / over quota — persistence is best-effort */
+    }
+  }, [state[0]]);
+  return state;
+}

--- a/webui/src/hooks/useTheme.test.ts
+++ b/webui/src/hooks/useTheme.test.ts
@@ -1,0 +1,53 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useTheme } from "./useTheme";
+
+function mockMatchMedia(prefersDark: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: prefersDark,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  document.documentElement.classList.remove("dark");
+  document.documentElement.style.colorScheme = "";
+});
+
+describe("useTheme", () => {
+  it("defaults to the OS preference when nothing is stored", () => {
+    mockMatchMedia(true);
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.theme).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(document.documentElement.style.colorScheme).toBe("dark");
+  });
+
+  it("prefers an explicit stored choice over the OS preference", () => {
+    mockMatchMedia(true);
+    localStorage.setItem("whisperx-webui-theme", "light");
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.theme).toBe("light");
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+  });
+
+  it("persists and applies the choice on toggle", () => {
+    mockMatchMedia(false);
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.theme).toBe("light");
+
+    act(() => result.current.toggle());
+
+    expect(result.current.theme).toBe("dark");
+    expect(localStorage.getItem("whisperx-webui-theme")).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+});

--- a/webui/src/hooks/useTheme.ts
+++ b/webui/src/hooks/useTheme.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from "react";
+
+export type Theme = "light" | "dark";
+
+const STORAGE_KEY = "whisperx-webui-theme";
+
+function systemTheme(): Theme {
+  return window.matchMedia?.("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function storedTheme(): Theme | null {
+  const v = localStorage.getItem(STORAGE_KEY);
+  return v === "light" || v === "dark" ? v : null;
+}
+
+function apply(theme: Theme): void {
+  const root = document.documentElement;
+  root.classList.toggle("dark", theme === "dark");
+  // Drives native controls (form widgets, scrollbars, the audio player).
+  root.style.colorScheme = theme;
+}
+
+/**
+ * Light/dark theme with an explicit user choice persisted to localStorage.
+ * Until the user picks, the UI follows the OS preference (and reacts to it
+ * live). An inline script in index.html applies the same value before paint,
+ * so the initial state here matches and there is no flash.
+ */
+export function useTheme() {
+  const [theme, setThemeState] = useState<Theme>(() => storedTheme() ?? systemTheme());
+
+  useEffect(() => {
+    apply(theme);
+  }, [theme]);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const onChange = () => {
+      if (!storedTheme()) setThemeState(mq.matches ? "dark" : "light");
+    };
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+
+  const setTheme = (next: Theme) => {
+    localStorage.setItem(STORAGE_KEY, next);
+    setThemeState(next);
+  };
+
+  return { theme, setTheme, toggle: () => setTheme(theme === "dark" ? "light" : "dark") };
+}

--- a/webui/src/hooks/useTranscriptionJob.ts
+++ b/webui/src/hooks/useTranscriptionJob.ts
@@ -1,0 +1,387 @@
+/**
+ * One transcription job = a synchronous POST plus a concurrent status feed.
+ *
+ * The POST only returns when the whole pipeline finishes, so the UI generates
+ * the request id itself, sends it as X-Request-ID, and follows
+ * GET /v1/audio/transcriptions/{id}/events (SSE, falling back to polling
+ * /status) to animate the stage timeline while the POST is in flight.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  ApiError,
+  fetchStoredResult,
+  getStatus,
+  isAbort,
+  isNetworkError,
+  newRequestId,
+  postTranscription,
+  streamStatusEvents,
+} from "../api/client";
+import type { RequestStatus, VerbosePayload } from "../api/types";
+import { buildFormFields, type TranscriptionOptions, wireFormat } from "../lib/options";
+
+const POLL_INTERVAL_MS = 1000;
+const STATUS_STREAM_DELAY_MS = 800;
+
+export type JobPhase = "idle" | "uploading" | "processing" | "completed" | "failed";
+
+export interface JobError {
+  message: string;
+  errorType: string | null;
+  cancelled: boolean;
+}
+
+export interface JobState {
+  phase: JobPhase;
+  requestId: string | null;
+  file: File | null;
+  /** Snapshot of the options the run was submitted with. */
+  options: TranscriptionOptions | null;
+  uploadProgress: number | null;
+  status: RequestStatus | null;
+  result: VerbosePayload | null;
+  error: JobError | null;
+  startedAtMs: number | null;
+  /** Set when the job completes; total wall-clock is finished−started. */
+  finishedAtMs: number | null;
+}
+
+const IDLE: JobState = {
+  phase: "idle",
+  requestId: null,
+  file: null,
+  options: null,
+  uploadProgress: null,
+  status: null,
+  result: null,
+  error: null,
+  startedAtMs: null,
+  finishedAtMs: null,
+};
+
+export interface TranscriptionJob {
+  state: JobState;
+  start: (file: File, options: TranscriptionOptions) => void;
+  cancel: () => void;
+  reset: () => void;
+}
+
+export function useTranscriptionJob(
+  apiKey: string | null,
+  mode: string | null,
+): TranscriptionJob {
+  const [state, setState] = useState<JobState>(IDLE);
+  const abortRef = useRef<(() => void) | null>(null);
+  const pollTimerRef = useRef<number | null>(null);
+  const statusTimerRef = useRef<number | null>(null);
+  const statusAbortRef = useRef<AbortController | null>(null);
+  const runSeqRef = useRef(0);
+
+  const stopStatusFeed = useCallback(() => {
+    if (pollTimerRef.current !== null) {
+      window.clearInterval(pollTimerRef.current);
+      pollTimerRef.current = null;
+    }
+    if (statusTimerRef.current !== null) {
+      window.clearTimeout(statusTimerRef.current);
+      statusTimerRef.current = null;
+    }
+    statusAbortRef.current?.abort();
+    statusAbortRef.current = null;
+  }, []);
+
+  useEffect(
+    () => () => {
+      stopStatusFeed();
+      abortRef.current?.();
+    },
+    [stopStatusFeed],
+  );
+
+  const start = useCallback(
+    (file: File, options: TranscriptionOptions) => {
+      const seq = ++runSeqRef.current;
+      const live = () => runSeqRef.current === seq;
+      const requestId = newRequestId();
+      const format = wireFormat(options, mode);
+      const jobMode = mode;
+      const jobKey = apiKey;
+
+      stopStatusFeed();
+      abortRef.current?.();
+
+      setState({
+        ...IDLE,
+        phase: "uploading",
+        requestId,
+        file,
+        options,
+        uploadProgress: 0,
+        startedAtMs: Date.now(),
+      });
+
+      const statusAbort = new AbortController();
+      statusAbortRef.current = statusAbort;
+
+      const applyStatus = (status: RequestStatus) => {
+        // The tracker sees the request before the pipeline finishes, so a
+        // terminal status is only the imminent-outcome hint; keep the phase and
+        // let the POST settle it (its error detail is richer).
+        setState((s) =>
+          s.phase === "completed" || s.phase === "failed" ? s : { ...s, status },
+        );
+      };
+
+      let pollBusy = false;
+      const poll = async () => {
+        if (pollBusy || !live()) return;
+        pollBusy = true;
+        try {
+          const status = await getStatus(requestId, jobKey);
+          if (live() && status !== null) applyStatus(status);
+        } finally {
+          pollBusy = false;
+        }
+      };
+
+      const beginPolling = () => {
+        if (pollTimerRef.current !== null || !live()) return;
+        pollTimerRef.current = window.setInterval(() => void poll(), POLL_INTERVAL_MS);
+      };
+
+      const beginStatusFeed = () => {
+        if (!live()) return;
+        statusTimerRef.current = window.setTimeout(() => {
+          if (!live() || statusAbort.signal.aborted) return;
+          void streamStatusEvents(requestId, jobKey, {
+            onStatus: (status) => {
+              if (live()) applyStatus(status);
+            },
+            signal: statusAbort.signal,
+          }).catch(() => {
+            if (live() && !statusAbort.signal.aborted) beginPolling();
+          });
+        }, STATUS_STREAM_DELAY_MS);
+      };
+
+      const handle = postTranscription({
+        file,
+        fields: buildFormFields(options, format),
+        requestId,
+        apiKey: jobKey,
+        onUploadProgress: (fraction) => {
+          if (!live()) return;
+          setState((s) =>
+            s.phase === "uploading" ? { ...s, uploadProgress: fraction } : s,
+          );
+        },
+        onUploadComplete: () => {
+          if (!live()) return;
+          setState((s) =>
+            s.phase === "uploading"
+              ? { ...s, phase: "processing", uploadProgress: 1 }
+              : s,
+          );
+          beginStatusFeed();
+        },
+      });
+      abortRef.current = handle.abort;
+
+      const finalStatus = async (): Promise<RequestStatus | null> =>
+        getStatus(requestId, jobKey);
+
+      handle.promise.then(
+        async ({ body }) => {
+          if (!live()) return;
+          stopStatusFeed();
+          let result: VerbosePayload;
+          try {
+            result = JSON.parse(body) as VerbosePayload;
+          } catch {
+            setState((s) => ({
+              ...s,
+              phase: "failed",
+              error: {
+                message: "The server returned an unparseable response.",
+                errorType: "bad_response",
+                cancelled: false,
+              },
+            }));
+            return;
+          }
+          const status = await finalStatus();
+          if (!live()) return;
+          setState((s) => ({
+            ...s,
+            phase: "completed",
+            result,
+            status: status ?? s.status,
+            finishedAtMs: Date.now(),
+          }));
+        },
+        async (err: unknown) => {
+          if (!live()) return;
+
+          if (isAbort(err)) {
+            stopStatusFeed();
+            setState((s) => ({
+              ...s,
+              phase: "failed",
+              error: {
+                message:
+                  jobMode === "kafka"
+                    ? "Cancelled. The server may still finish this job in the background."
+                    : "Cancelled.",
+                errorType: "cancelled",
+                cancelled: true,
+              },
+            }));
+            return;
+          }
+
+          // Connection lost mid-job. In Kafka mode the job keeps running
+          // server-side, so keep polling and recover the result from durable
+          // storage once the status turns terminal.
+          if (isNetworkError(err) && jobMode === "kafka") {
+            stopStatusFeed();
+            setState((s) => ({
+              ...s,
+              error: {
+                message: "Connection lost — waiting for the job via status polling…",
+                errorType: "connection_lost",
+                cancelled: false,
+              },
+            }));
+            const recovered = await recoverViaStatus(requestId, jobKey, live);
+            if (!live()) return;
+            stopStatusFeed();
+            setState((s) => applyRecovery(s, recovered));
+            return;
+          }
+
+          stopStatusFeed();
+          const status = await finalStatus();
+          if (!live()) return;
+          const apiErr = err instanceof ApiError ? err : null;
+          setState((s) => ({
+            ...s,
+            phase: "failed",
+            status: status ?? s.status,
+            error: {
+              message:
+                apiErr?.message ??
+                (err instanceof Error ? err.message : "Request failed."),
+              errorType:
+                apiErr?.errorType ??
+                status?.error_type ??
+                (apiErr ? `http_${apiErr.status}` : null),
+              cancelled: false,
+            },
+          }));
+        },
+      );
+    },
+    [apiKey, mode, stopStatusFeed],
+  );
+
+  const cancel = useCallback(() => {
+    abortRef.current?.();
+  }, []);
+
+  const reset = useCallback(() => {
+    runSeqRef.current++;
+    stopStatusFeed();
+    abortRef.current?.();
+    abortRef.current = null;
+    setState(IDLE);
+  }, [stopStatusFeed]);
+
+  return { state, start, cancel, reset };
+}
+
+type Recovery =
+  | { outcome: "completed"; result: VerbosePayload; status: RequestStatus | null }
+  | {
+      outcome: "failed";
+      message: string;
+      errorType: string | null;
+      status: RequestStatus | null;
+    };
+
+/** Poll until terminal, then pull the stored result (Kafka mode only). */
+async function recoverViaStatus(
+  requestId: string,
+  apiKey: string | null,
+  live: () => boolean,
+): Promise<Recovery> {
+  const deadline = Date.now() + 24 * 60 * 60 * 1000;
+  let status: RequestStatus | null = null;
+
+  while (live() && Date.now() < deadline) {
+    status = await getStatus(requestId, apiKey);
+    if (status?.status === "completed") {
+      try {
+        const { body } = await fetchStoredResult(
+          requestId,
+          "verbose_json",
+          false,
+          apiKey,
+        );
+        return {
+          outcome: "completed",
+          result: JSON.parse(body) as VerbosePayload,
+          status,
+        };
+      } catch (e) {
+        return {
+          outcome: "failed",
+          message: `Job completed but the stored result could not be fetched: ${
+            e instanceof Error ? e.message : String(e)
+          }`,
+          errorType: "result_fetch_failed",
+          status,
+        };
+      }
+    }
+    if (status?.status === "failed") {
+      return {
+        outcome: "failed",
+        message: status.error ?? "The job failed.",
+        errorType: status.error_type,
+        status,
+      };
+    }
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+  return {
+    outcome: "failed",
+    message: "Connection lost and the job outcome could not be recovered.",
+    errorType: "connection_lost",
+    status,
+  };
+}
+
+function applyRecovery(s: JobState, recovered: Recovery): JobState {
+  if (recovered.outcome === "completed") {
+    return {
+      ...s,
+      phase: "completed",
+      result: recovered.result,
+      status: recovered.status ?? s.status,
+      error: null,
+      finishedAtMs: Date.now(),
+    };
+  }
+  return {
+    ...s,
+    phase: "failed",
+    status: recovered.status ?? s.status,
+    error: {
+      message: recovered.message,
+      errorType: recovered.errorType,
+      cancelled: false,
+    },
+  };
+}

--- a/webui/src/hooks/useUnloadWarning.ts
+++ b/webui/src/hooks/useUnloadWarning.ts
@@ -1,0 +1,17 @@
+import { useEffect } from "react";
+
+/** Prompt the browser's "Leave site?" dialog before an unload while `enabled`
+ * — used to guard an in-progress or finished transcription (which cannot be
+ * restored after a reload) against accidental loss. */
+export function useUnloadWarning(enabled: boolean): void {
+  useEffect(() => {
+    if (!enabled) return;
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      // Legacy assignment required by some browsers to trigger the prompt.
+      e.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [enabled]);
+}

--- a/webui/src/hooks/useWindowDrop.ts
+++ b/webui/src/hooks/useWindowDrop.ts
@@ -1,0 +1,59 @@
+import { useEffect, useRef, useState } from "react";
+
+function hasFiles(e: DragEvent): boolean {
+  return Array.from(e.dataTransfer?.types ?? []).includes("Files");
+}
+
+/**
+ * Accept a file dropped anywhere on the page. Returns whether a file is
+ * currently being dragged over the window (to show an overlay). Drops already
+ * handled by a nested dropzone (which called preventDefault) are ignored, so
+ * this composes with the FileDrop button rather than double-handling.
+ */
+export function useWindowDrop(enabled: boolean, onFile: (file: File) => void): boolean {
+  const [dragging, setDragging] = useState(false);
+  const depth = useRef(0);
+
+  useEffect(() => {
+    if (!enabled) {
+      depth.current = 0;
+      setDragging(false);
+      return;
+    }
+    const onEnter = (e: DragEvent) => {
+      if (!hasFiles(e)) return;
+      depth.current += 1;
+      setDragging(true);
+    };
+    const onLeave = (e: DragEvent) => {
+      if (!hasFiles(e)) return;
+      depth.current = Math.max(0, depth.current - 1);
+      if (depth.current === 0) setDragging(false);
+    };
+    const onOver = (e: DragEvent) => {
+      if (hasFiles(e)) e.preventDefault();
+    };
+    const onDrop = (e: DragEvent) => {
+      if (!hasFiles(e)) return;
+      depth.current = 0;
+      setDragging(false);
+      if (e.defaultPrevented) return; // a nested dropzone already took it
+      e.preventDefault();
+      const file = e.dataTransfer?.files?.[0];
+      if (file) onFile(file);
+    };
+
+    window.addEventListener("dragenter", onEnter);
+    window.addEventListener("dragleave", onLeave);
+    window.addEventListener("dragover", onOver);
+    window.addEventListener("drop", onDrop);
+    return () => {
+      window.removeEventListener("dragenter", onEnter);
+      window.removeEventListener("dragleave", onLeave);
+      window.removeEventListener("dragover", onOver);
+      window.removeEventListener("drop", onDrop);
+    };
+  }, [enabled, onFile]);
+
+  return dragging;
+}

--- a/webui/src/index.css
+++ b/webui/src/index.css
@@ -1,0 +1,192 @@
+@import "tailwindcss";
+
+/* Manual toggle instead of Tailwind v4's default prefers-color-scheme: the
+   `dark:` variant activates whenever an ancestor carries the `.dark` class. */
+@custom-variant dark (&:where(.dark, .dark *));
+
+@theme {
+  --font-sans:
+    ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue",
+    Arial, sans-serif;
+  --font-mono:
+    ui-monospace, SFMono-Regular, "Cascadia Mono", Consolas, Menlo, monospace;
+
+  /* Terminal look: hairline-boxy corners across the whole radius scale. */
+  --radius-sm: 2px;
+  --radius-md: 2px;
+  --radius-lg: 3px;
+  --radius-xl: 4px;
+  --radius-2xl: 4px;
+}
+
+/* Semantic color roles — a single source of truth for the theme. Components use
+   the role utilities (bg-surface, text-fg, bg-accent, …); the raw values below
+   flip under `html.dark`, so no per-element `dark:` variant is needed. Palette is
+   a slate near-black neutral ramp with a single cyan accent (a muted green stays
+   for success). Light-mode cyan is darkened so text/fills keep WCAG AA. */
+:root {
+  --canvas: #f4f6f8;
+  --surface: #ffffff;
+  --surface-2: #eef1f4;
+  --fill: #e3e8ec;
+  --border: #dbe1e6;
+  --border-strong: #c4ccd3;
+  --fg: #0f141a;
+  --fg-muted: #47525b;
+  --fg-subtle: #626d76; /* AA (~4.6:1) on surface/canvas */
+
+  --accent: #0e7490; /* cyan-700 fill — white text clears AA */
+  --accent-strong: #155e75; /* cyan-800 hover */
+  --on-accent: #ffffff;
+  --accent-text: #0e7490; /* links/icons — AA on surface */
+  --accent-subtle: #ecfeff; /* cyan-50 active bg */
+
+  --success: #059669; /* emerald-600 */
+  --success-subtle: #ecfdf5;
+
+  --danger-text: #dc2626; /* red-600 */
+  --danger-strong: #991b1b; /* red-800 */
+  --danger-bg: #fef2f2; /* red-50  */
+  --danger-border: #fecaca; /* red-200 */
+
+  --warn-text: #b45309; /* amber-700 — AA on surface/canvas */
+  --warn-strong: #92400e; /* amber-800 */
+  --warn-bg: #fffbeb; /* amber-50  */
+  --warn-border: #fde68a; /* amber-200 */
+
+  --focus: #0891b2; /* cyan-600 ring */
+}
+
+html.dark {
+  --canvas: #0a0e12;
+  --surface: #0f141a;
+  --surface-2: #151b22;
+  --fill: #1c242d;
+  --border: #1e2730;
+  --border-strong: #2b3742;
+  --fg: #d7e0e8;
+  --fg-muted: #93a1ad;
+  --fg-subtle: #7c8894; /* AA (~4.7:1) on dark surface */
+
+  --accent: #22d3ee; /* cyan-400 */
+  --accent-strong: #06b6d4; /* cyan-500 hover */
+  --on-accent: #06232b; /* dark ink on bright cyan */
+  --accent-text: #22d3ee;
+  --accent-subtle: #0e3a4466; /* cyan tint / 40% */
+
+  --success: #34d399; /* emerald-400 */
+  --success-subtle: #064e3b66;
+
+  --danger-text: #f87171; /* red-400 */
+  --danger-strong: #fca5a5; /* red-300 */
+  --danger-bg: #450a0a66; /* red-950 / 40% */
+  --danger-border: #7f1d1d99; /* red-900 / 60% */
+
+  --warn-text: #fbbf24; /* amber-400 */
+  --warn-strong: #fcd34d; /* amber-300 */
+  --warn-bg: #451a0366; /* amber-950 / 40% */
+  --warn-border: #78350f99; /* amber-900 / 60% */
+
+  --focus: #22d3ee;
+}
+
+/* Register the roles as Tailwind color utilities. `inline` keeps them as
+   var() references so they resolve per-cascade (and flip under .dark). */
+@theme inline {
+  --color-canvas: var(--canvas);
+  --color-surface: var(--surface);
+  --color-surface-2: var(--surface-2);
+  --color-fill: var(--fill);
+  --color-border: var(--border);
+  --color-border-strong: var(--border-strong);
+  --color-fg: var(--fg);
+  --color-fg-muted: var(--fg-muted);
+  --color-fg-subtle: var(--fg-subtle);
+
+  --color-accent: var(--accent);
+  --color-accent-strong: var(--accent-strong);
+  --color-on-accent: var(--on-accent);
+  --color-accent-text: var(--accent-text);
+  --color-accent-subtle: var(--accent-subtle);
+
+  --color-success: var(--success);
+  --color-success-subtle: var(--success-subtle);
+
+  --color-danger-text: var(--danger-text);
+  --color-danger-strong: var(--danger-strong);
+  --color-danger-bg: var(--danger-bg);
+  --color-danger-border: var(--danger-border);
+
+  --color-warn-text: var(--warn-text);
+  --color-warn-strong: var(--warn-strong);
+  --color-warn-bg: var(--warn-bg);
+  --color-warn-border: var(--warn-border);
+
+  --color-focus: var(--focus);
+}
+
+html {
+  scrollbar-gutter: stable;
+}
+
+/* Sans-serif throughout; code/pre inherit it rather than the UA monospace. */
+body {
+  background-color: var(--color-canvas);
+  font-family: var(--font-sans);
+}
+
+code,
+kbd,
+samp,
+pre {
+  font-family: inherit;
+}
+
+::selection {
+  background: color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+/* Thin, tinted scrollbar for scrollable panels (e.g. long transcripts). */
+.term-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-strong) transparent;
+}
+
+/* Blinking block cursor used in the header and empty states. */
+.term-cursor {
+  display: inline-block;
+  width: 0.6em;
+  height: 1.05em;
+  vertical-align: text-bottom;
+  background: var(--accent);
+  animation: term-blink 1.1s steps(1) infinite;
+}
+@keyframes term-blink {
+  0%,
+  50% {
+    opacity: 1;
+  }
+  50.01%,
+  100% {
+    opacity: 0;
+  }
+}
+
+/* Skip layout/paint for off-screen transcript rows so very long transcripts stay
+   cheap to render — the browser reserves the estimated height until each row
+   scrolls into view (dependency-free alternative to list virtualization). */
+.segment-row {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 2.75rem;
+}
+
+/* Respect the OS "reduce motion" preference for the app's looping animations. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  ::before,
+  ::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/webui/src/main.tsx
+++ b/webui/src/main.tsx
@@ -1,0 +1,20 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+
+import App from "./App";
+import { ErrorBoundary } from "./components/ErrorBoundary";
+import { ToastProvider } from "./components/Toast";
+import "./index.css";
+
+const rootElement = document.getElementById("root");
+if (!rootElement) throw new Error("Root element #root not found");
+
+createRoot(rootElement).render(
+  <StrictMode>
+    <ErrorBoundary>
+      <ToastProvider>
+        <App />
+      </ToastProvider>
+    </ErrorBoundary>
+  </StrictMode>,
+);

--- a/webui/src/test/setup.ts
+++ b/webui/src/test/setup.ts
@@ -1,0 +1,41 @@
+import "@testing-library/jest-dom/vitest";
+
+// Under Node's experimental web storage, the global `localStorage` is present
+// but unusable without a backing file, which shadows jsdom's. Install a
+// deterministic in-memory Storage so hooks that persist to localStorage are
+// testable in isolation.
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>();
+  get length(): number {
+    return this.store.size;
+  }
+  clear(): void {
+    this.store.clear();
+  }
+  getItem(key: string): string | null {
+    return this.store.get(key) ?? null;
+  }
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+}
+
+const storage = new MemoryStorage();
+Object.defineProperty(globalThis, "localStorage", {
+  value: storage,
+  configurable: true,
+  writable: true,
+});
+if (typeof window !== "undefined") {
+  Object.defineProperty(window, "localStorage", {
+    value: storage,
+    configurable: true,
+    writable: true,
+  });
+}

--- a/webui/tsconfig.json
+++ b/webui/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "types": ["vite/client", "vitest/globals"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "useDefineForClassFields": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -1,0 +1,30 @@
+/// <reference types="vitest/config" />
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vitest/config";
+
+// Dev-server proxy target: a running whisperx-api-server instance.
+const API_TARGET = process.env.WEBUI_DEV_API ?? "http://localhost:8000";
+
+export default defineConfig({
+  // Assets are served by FastAPI under the /webui mount.
+  base: "/webui/",
+  plugins: [react(), tailwindcss()],
+  server: {
+    proxy: {
+      "/v1": API_TARGET,
+      "/info": API_TARGET,
+      "/healthcheck": API_TARGET,
+      "/models": API_TARGET,
+      "/docs": API_TARGET,
+      "/redoc": API_TARGET,
+      "/openapi.json": API_TARGET,
+    },
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./src/test/setup.ts"],
+    css: false,
+  },
+});


### PR DESCRIPTION
Changes:
- API: min/max_speakers, disk-backed result store (re-format results in both modes), SSE progress (…/events), GET /models/catalog, richer /info (max_upload_size_bytes, subtitle_formats_available).
- Web UI: React/Vite client served at /webui when WEBUI__ENABLED=true; built with Bun.
- CI: deploy-images.yml bakes web UI + metrics extra into published images, both runtime-gated, off by default.